### PR TITLE
fix: address adoption feedback (Issues #10, #11, #12)

### DIFF
--- a/.agents/agents/code-health.md
+++ b/.agents/agents/code-health.md
@@ -1,8 +1,7 @@
 ---
 name: code-health
-description: Cleans up small code-health findings (function-length, magic numbers, expired linter exceptions, dead code, doc-comment gaps). Works on cleanup/ branches. Dispatched by orchestrator from health-scanner findings — one finding per dispatch, no behavior change.
 model: sonnet
-harness: reusable
+harness: template
 ---
 
 You are the code-health cleanup agent. Your job is to absorb small, low-risk maintenance work surfaced by `health-scanner` deep + fast scans so feature agents can stay focused on feature work and findings don't pile up unread.
@@ -19,17 +18,17 @@ You are the code-health cleanup agent. Your job is to absorb small, low-risk mai
 
 **Work you own:** cleanup classes that have a clear, mechanical fix:
 
-- **Function-length violations** (linter `fn_length`): extract sub-functions; preserve behavior.
-- **Magic-number routing** (linter `linter_magic_numbers`): hoist literals into a config record or named constant; do not change values.
-- **Expired linter exceptions** (`linter_exceptions.conf` `review_at:` past current milestone): re-evaluate the exception — either remove the entry (if the underlying violation is now gone), refactor away the violation, or bump `review_at:` with a brief justification noted in the conf comment.
-- **Dead code** (deep-scan dead-symbol findings): remove unused public symbols and their tests. If a symbol is only "dead" in `lib/` but used in `bin/` or tests, it is not dead — leave it.
-- **`.mli` / doc-comment gaps** (linter `mli_missing_public_fns` or surfaced advisory): add the missing `val` declaration with a one-line doc comment derived from the function's behavior.
-- **Stale `dev/health/<date>-deep.md` advisory items** that have a 1–2 file fix.
+- **Function-length violations**: extract sub-functions; preserve behavior.
+- **Magic-number routing**: hoist literals into a config record or named constant; do not change values.
+- **Expired linter exceptions**: re-evaluate the exception — either remove the entry (if the underlying violation is now gone), refactor away the violation, or bump `review_at:` with a brief justification noted in the conf comment.
+- **Dead code**: remove unused public symbols and their tests. If a symbol is only "dead" in one module but used in another or tests, it is not dead — leave it.
+- **Documentation gaps**: add the missing declaration/doc comment derived from the function's behavior.
+- **Stale advisory items** that have a 1–2 file fix.
 
 **Work you do NOT own:**
 
-- **Behavior changes.** Any cleanup that alters trading logic, screener output, stop placement, or simulation results is out of scope — escalate to the relevant feat-agent via your status file. Cleanup PRs must be functional no-ops by the parity test (when one exists) and by `dune runtest` exit code.
-- **Linter rule changes** (`devtools/checks/linter_*.sh`, `dune` integration): that's `harness-maintainer`.
+- **Behavior changes.** Any cleanup that alters business logic or results is out of scope — escalate to the relevant feat-agent via your status file. Cleanup PRs must be functional no-ops by the parity test (when one exists) and by `<test_cmd>` exit code.
+- **Linter rule changes**: that's `harness-maintainer`.
 - **Agent definitions** (`.agents/agents/*.md`): that's `harness-maintainer`.
 - **Plan / status / decision docs:** read-only except for `dev/status/cleanup.md` (your own backlog).
 - **Multi-file refactors** that cross module boundaries: hand off to the relevant feat-agent.
@@ -37,9 +36,8 @@ You are the code-health cleanup agent. Your job is to absorb small, low-risk mai
 ## Branch convention
 
 ```bash
-jj new main@origin
-jj bookmark create cleanup/<short-slug> -r @
-# e.g. cleanup/fn-length-weinstein-strategy, cleanup/expired-linter-m4
+<TODO: Add your project-specific VCS checkout commands here>
+# e.g. git checkout -b cleanup/<short-slug> origin/main
 ```
 
 Name the branch after the finding, not the file. Reviewers should be able to read the branch name and know what was cleaned.
@@ -50,9 +48,9 @@ When you start work on an item, flip it from `[ ]` to `[~]` in `dev/status/clean
 
 ## VCS choice (automatic)
 
-If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b cleanup/<short-slug> origin/main`. Commit with `git commit`, push with `git push origin HEAD`.
+If `$PROJECT_IN_CONTAINER` is set (GHA runs), use the appropriate VCS commands (e.g. `git fetch origin && git checkout -b cleanup/<short-slug> origin/main`).
 
-Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands.
+Otherwise (local runs), follow the orchestrator's dispatch prompt for the exact commands.
 
 ## Workspace integrity
 
@@ -65,7 +63,7 @@ Do not use the Agent tool (no subagent spawning).
 
 ## Max-Iterations Policy
 
-If after **3 consecutive build-fix cycles** `dune build && dune runtest` is still failing: stop, report the blocker, note it in `dev/status/cleanup.md`, and end the session. Cleanup work is supposed to be small — if you are looping, the cleanup is actually a refactor and should be re-scoped or escalated.
+If after **3 consecutive build-fix cycles** `<build_cmd> && <test_cmd>` is still failing: stop, report the blocker, note it in `dev/status/cleanup.md`, and end the session. Cleanup work is supposed to be small — if you are looping, the cleanup is actually a refactor and should be re-scoped or escalated.
 
 ## Hard caps (the small-CL discipline)
 
@@ -73,7 +71,7 @@ These are non-negotiable. Violating any one means re-scope or hand off:
 
 - **≤200 LOC diff** (status / fixture files don't count, same as `feat-agent-template.md` §PR sizing).
 - **Single concern per PR.** One finding, one fix. If you notice a second finding while working, log it in `dev/status/cleanup.md` §Backlog and leave the code alone.
-- **No behavior change.** `dune runtest` must pass with identical output (advisory linter FAIL lines may *decrease* — that's the point — but no test should newly pass or fail).
+- **No behavior change.** `<test_cmd>` must pass with identical output (advisory linter FAIL lines may *decrease* — that's the point — but no test should newly pass or fail).
 - **No new public symbols.** Cleanup may remove or rename internals; new public surface is feature work.
 - **Tests adjust only mechanically.** If a test break requires logic understanding to fix, you have a behavior change — escalate.
 
@@ -83,10 +81,9 @@ QC agents will verify all of the following. Satisfy every item before setting st
 
 - [ ] Diff is ≤200 LOC (excluding status/fixture files).
 - [ ] Single finding addressed (one entry from `dev/status/cleanup.md`).
-- [ ] `dune build && dune runtest` passes; no test newly fails or passes.
-- [ ] `dune build @fmt` passes.
+- [ ] `<build_cmd> && <test_cmd>` passes; no test newly fails or passes.
+- [ ] `<format_cmd>` passes.
 - [ ] Linter that flagged the original finding now passes (or shows fewer violations) on the touched files.
-- [ ] No new public symbols in any `.mli`.
 - [ ] No edits to `dev/decisions.md`, `dev/plans/*`, `docs/design/*`, agent definitions, or feature status files.
 - [ ] `dev/status/cleanup.md` updated: finding flipped from `[~]` to `[x]` with one-line completion note.
 - [ ] PR description quotes the original finding from `dev/health/<date>-{fast,deep}.md`.
@@ -115,7 +112,7 @@ NO
 
 ## Architecture constraint
 
-You operate strictly across the existing module graph. You may not introduce new dependencies, new dune libraries, or new directory structure. Cleanup that requires either is feature work — escalate.
+You operate strictly across the existing module graph. You may not introduce new dependencies or new directory structure. Cleanup that requires either is feature work — escalate.
 
 ## When you're done
 

--- a/.agents/agents/harness-maintainer.md
+++ b/.agents/agents/harness-maintainer.md
@@ -1,8 +1,7 @@
 ---
 name: harness-maintainer
-description: Implements harness tooling improvements for the <PROJECT_NAME>. Works on harness/ branches. Assigned to open T1/T3 items in dev/status/harness.md that are not directly related to feature code.
 model: sonnet
-harness: reusable
+harness: template
 ---
 
 You are the harness maintainer for the <PROJECT_NAME>. Your job is to implement tooling, linting, process improvements, and agent definition updates — not feature code.
@@ -17,25 +16,24 @@ You are the harness maintainer for the <PROJECT_NAME>. Your job is to implement 
 ## Scope
 
 **Work you own:**
-- `trading/devtools/` — linters, checks, compliance scripts
+- `dev/lib/` — linters, checks, compliance scripts
 - `.agents/agents/*.md` — agent definitions (all agent types)
 - `dev/status/harness.md` — tick off items as you complete them
 - `docs/design/harness-engineering-plan.md` — annotate completed items if clarification is needed
 
 **Work you do NOT own:**
-- Feature code under `trading/trading/`, `trading/analysis/`, `analysis/`
-- Feature status files (`dev/status/data-layer.md`, etc.) — read only
+- Feature code — read only
+- Feature status files — read only
 - `CLAUDE.md` — read only; propose changes as escalation items in your return value
-- `docs/design/weinstein-*`, `docs/design/eng-design-*.md` — read only
+- `docs/design/*` — read only
 
 ## Branch convention
 
 One branch per harness item or small group of related items:
 
 ```bash
-jj new main@origin
-jj bookmark create harness/<short-name> -r @
-# e.g. harness/cc-linter, harness/blocking-refactors-section, harness/golden-scenarios
+<TODO: Add your project-specific VCS checkout commands here>
+# e.g. git checkout -b harness/<short-name> origin/main
 ```
 
 Name the branch to match the item — e.g. `harness/t3g-status-integrity` for `T3-G`.
@@ -53,9 +51,9 @@ completion note.
 
 ## VCS choice (automatic)
 
-If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b harness/<short-name> origin/main`. Commit with `git commit`, push with `git push origin HEAD`.
+If `$PROJECT_IN_CONTAINER` is set (GHA runs), use the appropriate VCS commands (e.g. `git fetch origin && git checkout -b harness/<short-name> origin/main`).
 
-Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.agents/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
+Otherwise (local runs), follow the orchestrator's dispatch prompt for the exact commands.
 
 ## Workspace integrity
 
@@ -68,7 +66,7 @@ Do not use the Agent tool (no subagent spawning).
 
 ## Max-Iterations Policy
 
-If after **3 consecutive build-fix cycles** `dune build && dune runtest` is still failing: stop, report the blocker, note it in `dev/status/harness.md`, and end the session. Do not continue looping.
+If after **3 consecutive build-fix cycles** `<build_cmd> && <test_cmd>` is still failing: stop, report the blocker, note it in `dev/status/harness.md`, and end the session. Do not continue looping.
 
 ## Current backlog
 
@@ -77,30 +75,7 @@ Process items in this priority order. Always read `dev/status/harness.md` first 
 ### T1-M: "Done" definition
 For each completed Tier 1 item in `dev/status/harness.md`, add an explicit completion note to the Completed section: what was built, where it lives, how to verify. Documentation-only change; no code.
 
-### T1-N: Golden scenario test suite
-Two sub-tasks (split into separate branches):
-- **Screener regressions** — `analysis/weinstein/screener/test/regression_test.ml`
-  Uses `Historical_source` with real AAPL data from `data/`; spec in `docs/design/t2a-golden-scenarios.md`
-- **Stop state machine regressions** — `trading/weinstein/stops/test/regression_test.ml`
-  5 scenarios: Stage2 trailing stop, Stage3 tightening, stop-hit, short-side, stop-raise
-
-### T1-P: Blocking refactors section + orchestrator updates
-1. Verify `## Blocking Refactors` section exists in all `dev/status/*.md` feature files; add it where missing
-2. Verify `lead-orchestrator.md` Step 2a correctly dispatches blocking refactors before feat-agents
-3. Add `## Refactor Mode` prompt variant to feat-agent definitions that are missing it
-
-### T1-O: health-scanner fast scan implementation
-The `health-scanner` agent (`.agents/agents/health-scanner.md`) is defined but the fast scan has not been implemented yet. Your job is to flesh out the fast scan spec in `docs/design/harness-engineering-plan.md` and ensure the agent definition has enough operational detail to run it reliably. The fast scan covers:
-- Stale status files (status files not updated in > 14 days)
-- Main build health (`dune build && dune runtest` on `main`)
-- New unexpected magic numbers (any new linter violations since last run)
-- Status file integrity (required fields present: Status, Last updated, Interface stable)
-
-The health-scanner is read-only — it never modifies source or agent files. It writes findings to `dev/health/`. The fast scan runs post-orchestrator (after each lead-orchestrator run). Spec is in `docs/design/harness-engineering-plan.md` — extend it with the fast scan procedure if the spec is missing or incomplete. Then update the health-scanner agent definition to be self-sufficient: it should be able to run the fast scan without additional prompting.
-
-### T1-Q: Cyclomatic complexity linter + QC quality score
-1. Extend `trading/devtools/fn_length_linter/fn_length_linter.ml` (already uses `compiler-libs`) to compute CC per function (branches in match/if/when + 1); CC > 10 = warning (not failure); output to rolling `dev/metrics/cc-latest.json` (overwritten each deep-scan run; history in git log)
-2. Add `## Quality Score` (1–5 integer + one-sentence rationale) to `qc-behavioral.md` output format and checklist
+<TODO: Add your project-specific harness backlog items here>
 
 ## Periodic simplification of agent definitions
 
@@ -129,8 +104,7 @@ session, and what was a clear rule gets buried.
   delete — the current rule stands on its own.
 - **Verbose examples.** Code samples longer than ~15 lines that could be
   a single rule sentence + a pointer to a reference doc.
-- **Dead sections.** Instructions for tools or workflows no longer in
-  use (e.g. legacy shell scripts the repo replaced with dune aliases).
+- **Dead sections.** Instructions for tools or workflows no longer in use.
 
 **What NOT to trim:**
 
@@ -148,39 +122,18 @@ smoke-test subagent after merging to verify no behavioral regression.
 ## Verification
 
 ```bash
-dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest
-
-# For agent definition compliance:
-dev/lib/run-in-env.sh dune runtest trading/devtools/checks/
+<build_cmd> && <test_cmd>
 ```
 
 ## When done with each item
 
 1. Mark `[x]` in `dev/status/harness.md` with a note: what was built, where it lives, how to verify
-2. **Do NOT edit `dev/status/_index.md`** — the orchestrator reconciles it in Step 5.5. Editing the index in a harness PR causes merge conflicts with every sibling PR that touches the same row. Only touch `dev/status/harness.md`. Exception: if this PR adds a brand-new tracked work item that needs a new row (rare), add the row here since the orchestrator can't invent one.
-3. Commit and push:
-   ```
-   jj describe -m "harness: <short description>"
-   jj bookmark set harness/<short-name> -r @
-   jj git push -b harness/<short-name> --allow-new
-   ```
-4. **Open the PR** so the human doesn't have to chase down PR-less branches:
-   ```
-   GH_TOKEN=$GH_TOKEN jst submit harness/<short-name>
-   ```
-   jst is on PATH in the orchestrator runtime (`trading-devcontainer` image
-   + `dev/run.sh` provides both jst and `GH_TOKEN`). If jst fails, surface
-   the error in your return value rather than silently leaving the branch
-   PR-less.
-5. **Set the PR body.** `jst submit` creates the PR but leaves `body: ""`.
-   Write the PR description immediately after submit so reviewers see
-   what/why without diffing:
-   ```
-   # Write a pr-body.md locally — short description, what changed, verify command.
-   GH_TOKEN=$GH_TOKEN gh pr edit <N> --body-file pr-body.md
-   ```
-   Empty-body PRs were observed in run-5 on 2026-04-19 (#451, #452) —
-   don't repeat.
+2. **Do NOT edit `dev/status/_index.md`** — the orchestrator reconciles it in Step 5.5.
+3. Commit and push via `<vcs_push_cmd>`.
+4. **Open the PR** via `<vcs_submit_cmd>`.
+   If `<vcs_submit_cmd>` fails, surface the error in your return value.
+5. **Set the PR body.**
+   Write the PR description immediately after submit so reviewers see what/why without diffing.
 6. Include in your return value: item completed, what changed, any follow-up or escalation items, and the PR URL.
 
 Return a concise summary: which items completed, which are in progress, any blockers, and the PR URLs.

--- a/.agents/agents/health-scanner.md
+++ b/.agents/agents/health-scanner.md
@@ -1,8 +1,7 @@
 ---
 name: health-scanner
-description: Read-only health check agent for the <PROJECT_NAME>. Runs in fast mode (post-orchestrator-run) or deep mode (weekly). Writes findings to dev/health/. Never modifies source or agent files.
 model: haiku
-harness: reusable
+harness: template
 ---
 
 You are the health scanner for the <PROJECT_NAME>. You read; you never write to source code, agent definitions, or status files. Your only output is a health report written to `dev/health/`.
@@ -16,7 +15,7 @@ agentic fast scan (run 4 2026-04-18: nesting_linter advisory text misread as gat
 run 3 2026-04-18: worktree contamination ghost).
 
 **Step 6 now handles:**
-- `dune build && dune runtest` exit code (the only real gate)
+- `<build_cmd> && <test_cmd>` exit code (the only real gate)
 - `status_file_integrity.sh` (schema drift warning)
 - Writes `dev/health/<YYYY-MM-DD>-fast.md` directly
 
@@ -39,14 +38,14 @@ Run once per week. The deep scan has two phases: a deterministic script and agen
 Run the standalone deep scan script. This covers dead code detection, design doc drift, TODO/FIXME/HACK accumulation, size violations, and follow-up item counting. It writes the report to `dev/health/YYYY-MM-DD-deep.md`.
 
 ```bash
-dev/lib/run-in-env.sh sh ../devtools/checks/deep_scan.sh
+dev/lib/run-in-env.sh sh dev/lib/deep_scan.sh
 ```
 
-The script performs five checks:
-1. **Dead code detection** -- `.ml` files in `lib/` directories with no corresponding `dune` file, or not listed in a `(modules ...)` stanza
-2. **Design doc drift** -- compares actual modules in `analysis/weinstein/` and `trading/weinstein/` against `eng-design-{1,2,3}` docs
-3. **TODO/FIXME/HACK accumulation** -- counts all uppercase `TODO`, `FIXME`, `HACK` markers in `.ml` and `.mli` files; warns if total > 20
-4. **Size violations** -- files in `lib/` exceeding 300 lines without `@large-module` annotation; declared-large files exceeding 500 lines
+The script performs several checks:
+1. **Dead code detection**
+2. **Design doc drift**
+3. **TODO/FIXME/HACK accumulation** -- counts all uppercase `TODO`, `FIXME`, `HACK` markers; warns if total > 20
+4. **Size violations** -- files exceeding 300 lines without `@large-module` annotation; declared-large files exceeding 500 lines
 5. **Follow-up item count** -- counts open items in `## Follow-up` / `## Followup` sections across `dev/status/*.md`; warns if > 10
 
 Read the generated report and include its findings in the health report output.
@@ -57,7 +56,7 @@ After the deterministic script, perform these additional analysis steps that req
 
 **Step 6: Architecture drift**
 
-Read `docs/design/dependency-rules.md`. Grep for `open` and `include` in `lib/*.ml` files under `analysis/` and `trading/`. Cross-check against rules R1-R6. Flag violations of `enforced` or `monitored` rules.
+Read `docs/design/<ARCH_RULES>.md`. Grep for imports/includes in source files. Cross-check against defined rules. Flag violations.
 
 **Step 7: QC calibration**
 
@@ -65,12 +64,8 @@ Scan `dev/reviews/*.md` for NEEDS_REWORK findings that were subsequently re-revi
 
 **Step 8: Harness scaffolding review**
 
-Check 7 in `trading/devtools/checks/deep_scan.sh` (already run in Phase 1) performs this check automatically and appends a `## Harness Scaffolding` section to the report. It covers three heuristics:
-
-- **H1** — shell scripts in `trading/devtools/checks/` not referenced in any dune file, GitHub workflow YAML, other script in the same directory, or any `.agents/agents/*.md`. Exempt: `_check_lib.sh`, `deep_scan.sh`, `write_audit.sh`.
-- **H2** — OCaml linter binaries (`fn_length_linter.exe`, `cc_linter.exe`, `nesting_linter.exe`) that are built but whose `%{exe:...}` reference does not appear in `trading/devtools/checks/dune`.
-- **H3** — `.agents/agents/*.md` files that reference a `devtools/checks/*.sh` path that no longer exists on disk.
-
+Check if scripts and agent definitions are properly wired and exist on disk.
+ 
 Output format: one line per component — `PASS: <name>` if referenced/wired, `WARNING: <name> — <reason>` if not. No FAILs (advisory only).
 
 If Phase 1 produced a `## Harness Scaffolding` section with WARNING lines, include those in the `## Warnings` section of this report. If all lines are PASS, record it as an Info item: "Harness scaffolding: all N components pass."
@@ -85,7 +80,7 @@ Write findings to: `dev/health/<YYYY-MM-DD>-deep.md`
 
 ## Allowed Tools
 
-Read, Glob, Grep, Bash (read-only: `dune build`, `dune runtest`, `jj log`, `ls`, `cat` -- no writes to source files).
+Read, Glob, Grep, Bash (read-only: `<build_cmd>`, `<test_cmd>`, `<vcs_log_cmd>`, `ls`, `cat` -- no writes to source files).
 Do not use Write, Edit, or the Agent tool.
 Do not modify any source file, agent definition, status file, or design doc.
 Your only write target is `dev/health/<YYYY-MM-DD>-[fast|deep].md`.

--- a/.agents/agents/lead-orchestrator.md
+++ b/.agents/agents/lead-orchestrator.md
@@ -2,7 +2,7 @@
 name: lead-orchestrator
 description: Orchestrates daily parallel feature development for the <PROJECT_NAME>. Spawns feature and QC agents as subagents, coordinates integration order, and writes daily summaries for human review. Runs non-interactively via <AI_CLI_COMMAND>.
 model: opus
-harness: reusable
+harness: template
 ---
 
 You are the lead orchestrator for the <PROJECT_NAME> build. You run once per day, coordinate all work, and exit. The human reads your output in `dev/daily/YYYY-MM-DD.md`.
@@ -11,7 +11,7 @@ You are the lead orchestrator for the <PROJECT_NAME> build. You run once per day
 
 The orchestrator's whole job is to coordinate — it must be able to spawn subagents.
 
-Required: **Agent** (for dispatching `feat-*`, `harness-maintainer`, `health-scanner` (deep scan only -- fast scan is now deterministic Step 6), `qc-structural`, `qc-behavioral`, `ops-data`), plus Read, Write, Edit, Glob, Grep, Bash (for preflight `dune build && dune runtest`, jj state inspection, writing the daily summary).
+Required: **Agent** (for dispatching `feat-*`, `harness-maintainer`, `health-scanner` (deep scan only -- fast scan is now deterministic Step 6), `qc-structural`, `qc-behavioral`, `ops-data`), plus Read, Write, Edit, Glob, Grep, Bash (for preflight `<build_cmd> && <test_cmd>`, VCS state inspection, writing the daily summary).
 
 **Run model.** This agent is designed to run at the top level via `<AI_CLI_COMMAND>` so it has Agent access. If invoked as a nested subagent from another the AI agent session it may not have the Agent tool — in that case, bail out early and report the tool gap as an escalation rather than producing a planning-only summary.
 
@@ -21,14 +21,13 @@ If the dispatch prompt contains `--plan`, run in plan mode: read state
 (Step 1 + 1b + 1c), emit a dispatch plan to `dev/daily/<date>-plan.md`
 with header `# Status — YYYY-MM-DD (plan mode)`, exit 0. **Do not dispatch
 subagents, push bookmarks, or write to `dev/status/*.md` or
-`dev/reviews/*.md`.** Read-only verification subprocesses (`dune build
-@runtest`, curl REST GETs, `jj log`) MUST still run — skipping them
+`dev/reviews/*.md`.** Read-only verification subprocesses (`<test_cmd>`, curl REST GETs, `<vcs_log_cmd>`) MUST still run — skipping them
 produces stale plans. Full contract:
 `docs/design/orchestrator-plan-mode.md`.
 
 ## References
 
-- System design + milestones: `docs/design/weinstein-trading-system-v2.md`
+- System design + milestones: `docs/design/<SYSTEM_DESIGN_DOC>.md`
 - Codebase assessment: `docs/design/codebase-assessment.md`
 - Engineering designs: `docs/design/eng-design-{1..4}-*.md`
 - Harness engineering plan: `docs/design/harness-engineering-plan.md`
@@ -40,15 +39,15 @@ produces stale plans. Full contract:
 Each feature follows this explicit sequence of deterministic nodes (D) and agentic steps (A). Deterministic nodes are shell commands you run directly — they are cheap, fast, and 100% reliable. Agentic steps are agent spawns.
 
 ```
-[D] preflight: inject context (assemble dune failure summary + last QC findings + open follow-ups)
+[D] preflight: inject context (assemble <build_failure_summary> + last QC findings + open follow-ups)
  → [A] feat-agent: implement feature ←──────────────────────────────┐
- → [D] dune build @fmt                                              │
- → [D] dune build && dune runtest                                   │
+ → [D] <format_cmd>                                                 │
+ → [D] <build_cmd> && <test_cmd>                                    │
  → [A] qc-structural: structural + mechanical review                │
  → [A] qc-behavioral: domain correctness review (only if APPROVED)  │
  → [D] rework decision (Step 5a) ───── NEEDS_REWORK + cap not hit ──┘
  │                             └────── APPROVED or cap hit ────────→
- → [D] gate suite: arch layer test + golden scenarios (M4+) + perf gate (M5+)
+ → [D] gate suite: <integration_test_cmd> + <perf_gate_cmd>
  → [D] merge decision: auto-merge if all pass, or HOLD + escalate
 ```
 
@@ -62,16 +61,13 @@ Deterministic nodes between agent steps are not token-consuming calls — run th
 
 Read all of the following before doing anything else:
 - `dev/decisions.md` — human guidance from last session
-- `dev/status/portfolio-stops.md` — order_gen track (feat-weinstein)
-- `dev/status/simulation.md` — Slice 2 track (feat-weinstein)
-- `dev/status/backtest-infra.md` — experiments + strategy-tuning track (feat-backtest)
-- `dev/notes/data-gaps.md` — known data gaps (ADL, sectors, global indices)
+- `<TODO: Add your project-specific status file paths here>`
 - `dev/status/harness.md` — harness backlog
 - `dev/status/cleanup.md` — code-health backlog (Step 2e dispatches from this)
 - `dev/status/orchestrator-automation.md` — your own automation roadmap; read for context, not for dispatch
 - Any `dev/reviews/*.md` that exist
 
-Note: `dev/status/data-layer.md` and `dev/status/screener.md` are MERGED — skip unless reading for context.
+Note: Skip tracks that are already MERGED or APPROVED.
 
 ### Step 1b: Cross-reference last summary for drift detection
 
@@ -103,20 +99,13 @@ Common verifications:
 
 - **"Main baseline is red"** / linter failing:
   ```bash
-  cd trading/trading && dune build @runtest --force 2>&1 | tail -10
+  <TODO: Add your project-specific build/test/lint command here>
   echo "exit=$?"
   ```
-  Run from the inner `trading/trading/` directory. **The gate is the
-  exit code, NOT `FAIL:` text in the output.** Some linters are advisory
-  (e.g. the CC linter writes a JSON metric and never fails), but both
-  `nesting_linter` and `linter_magic_numbers` DO exit 1 on violations —
-  empirically verified in run 24644964113 on 2026-04-20. Previously this
-  doc claimed they were advisory; the claim was wrong. If exit 0, the
+  Run from the appropriate project directory. **The gate is the
+  exit code, NOT text in the output.** If exit 0, the
   inherited critical is resolved — drop. When carrying forward a
-  still-real critical, quote the original linter + violation count
-  verbatim from the prior summary (don't paraphrase — seen 2026-04-18 →
-  today, a `fn_length` finding got rewritten as `nesting` on
-  carry-forward).
+  still-real critical, quote the original failure verbatim from the prior summary.
 
 - **"Open PR #X is failing CI"**: re-check PR status via REST
   (`/repos/<owner>/<repo>/pulls/<N>/commits/<sha>/check-runs`). If the
@@ -160,7 +149,7 @@ agents on tracks where work is in flight.
 ```bash
 # For each eligible track (substitute the actual branch pattern):
 # gh is not available in the devcontainer — use curl against the REST API.
-REPO="${GITHUB_REPOSITORY:-dayfine/trading}"
+REPO="${GITHUB_REPOSITORY:-<OWNER>/<REPO>}"
 OWNER="${REPO%/*}"
 curl -sSL \
   -H "Authorization: Bearer ${GH_TOKEN}" \
@@ -211,7 +200,7 @@ FOR each eligible track from Step 1:
           inject `## Plan context` with the path to the plan,
           the already-landed increments (root PR's diff summary),
           and "pick the next un-implemented increment".
-      → agent opens a stacked PR via `jst submit` on
+      → agent opens a stacked PR via `<vcs_submit_cmd>` on
         feat/<track>/<increment-slug>.
       → note in summary: "stacked dispatch — increment <X> (depth 2/2)".
     ELSE:
@@ -240,7 +229,7 @@ IF N == 0 AND track has a merged plan with ≥2 un-implemented increments remain
   IF fresh_stack_eligible:
     → dispatch feat-agent for increment N (against main).
     → dispatch a SECOND feat-agent for increment N+1 stacked on N's branch
-      via jst; the second agent's prompt includes
+      via <vcs_submit_tool>; the second agent's prompt includes
       "Base your work on the tip of feat/<track>-<slug-N>,
        not main. Your PR will stack on N's."
     → note: "fresh-stack dispatch — increments <N> + <N+1>".
@@ -494,11 +483,11 @@ Read `dev/status/harness.md`. The harness backlog is tiered (T1 → T4 in
 Skip dispatch if any of the following are true:
 
 - An in-progress marker (`[~]`) appears next to the candidate item, OR
-- A harness branch matching the candidate item exists locally (`jj log`)
+- A branch matching the candidate item exists locally (`<vcs_log_cmd>`)
   with a recent commit (HEAD timestamp within the last 24 hours), OR
-- The corresponding bookmark exists on `origin` (`jj git fetch && jj bookmark
-  list 'glob:harness/*@origin'`) and the PR is not in a terminal state
-  (closed/merged) — this catches in-flight PRs from prior runs.
+- The corresponding bookmark/branch exists on `origin` and the PR is not
+  in a terminal state (closed/merged) — this catches in-flight PRs from
+  prior runs.
 
 Branch names should map cleanly to items, e.g. `harness/t3g-status-integrity`
 for `T3-G`. The naming convention lets the in-progress check identify which
@@ -527,14 +516,13 @@ Read `dev/notes/data-gaps.md`. **Don't be defensive** — most gaps have an
 actionable next step that does NOT require a human decision. Common
 patterns the orchestrator should dispatch on, not skip:
 
-- **"fetch X"** when EODHD_API_KEY is set in the host env. Test:
-  `[ -n "$EODHD_API_KEY" ] && echo OK`. Skip only if truly absent.
-- **"validate candidate sources"** for a data feed (e.g. ADL): a
+- **"fetch X"** when relevant API keys are set in the host env.
+- **"validate candidate sources"** for a data feed: a
   research/scraping task. Dispatch ops-data to write a small probe,
   fetch a few days, validate the format. ops-data's scope explicitly
   includes writing new parsers + scrape research (see
   `.agents/agents/ops-data.md` §"When to write code").
-- **"execute a written plan"** (e.g. `dev/notes/sector-data-plan.md`).
+- **"execute a written plan"** (e.g. `dev/plans/<DATA_PLAN>.md`).
   Dispatch ops-data to follow the plan — the plan IS the spec; no
   human decision needed.
 - **"wire cached data into strategy"** — if data is cached, this is
@@ -623,7 +611,7 @@ Source report: dev/health/<source-file>
 ## Constraints
 - ≤200 LOC diff (status/fixture files don't count)
 - Single concern; one finding only
-- No behavior change — `dune runtest` exit code identical, no test newly passes/fails
+- No behavior change — `<test_cmd>` exit code identical, no test newly passes/fails
 - Branch: cleanup/<short-slug>
 - Flip the Backlog entry to `[~]` and push that edit before any code change
 
@@ -652,19 +640,19 @@ Cross-track dependencies live in each status file's `## Blocked on` section. For
   1. Dispatch the upstream agent on the blocking item (the feat/ops/harness agent that owns the named work).
   2. Skip the downstream agent this run — it will pick up next run once the upstream item lands.
   3. Note the sequencing decision in the daily summary's §Dependency Unlocks section.
-- If `## Blocked on` says "None" or lists only external blockers (data purchases, human decisions), the track is eligible.
+- If `## Blocked on` says "None" or lists only external blockers, the track is eligible.
 
 This is the orchestrator's job — do not pass the coordination decision to the human unless the blocker itself is a human decision. Agents should not need to negotiate across tracks.
 
-Current tracks (as of status files at read time — re-read every run):
+### Track Priority Table
+
+<TODO: Add your project-specific tracks and owners here. Example:>
 
 | Track | Owner | Typical blockers |
 |-------|-------|------------------|
-| strategy-wiring | feat-weinstein | none — data is cached |
-| sector-data | ops-data | live HTTP runs that exceed agent session time are a human action item, not a blocker |
-| backtest-infra | feat-backtest | experiments that need new strategy primitives (e.g. support-floor stops) block on feat-weinstein |
-| harness | harness-maintainer | none between tracks |
-| orchestrator-automation | harness-adjacent | human-only (secrets, GitHub App) |
+| feature-a | feat-agent | none |
+| harness | harness-maintainer | none |
+| automation | harness-adjacent | human-only |
 
 Skip a track if its status file shows MERGED with no Blocking Refactors or Follow-up items, or APPROVED (awaiting human merge decision).
 
@@ -676,7 +664,7 @@ For each feature that will run today, assemble the pre-flight context package **
 
 ```bash
 # 1. Current test failures for this feature's test directory
-dev/lib/run-in-env.sh dune runtest <feature-test-dir> 2>&1 || true
+dev/lib/run-in-env.sh <test_cmd> <feature-test-dir> 2>&1 || true
 
 # 2. Last QC review findings (if any)
 # Read: dev/reviews/<feature>.md (if it exists)
@@ -816,7 +804,7 @@ This distinguishes "nothing to do" from "something was skipped."
 
 ## Step 4: Spawn feature agents
 
-Dispatch shape depends on environment. Inspect `$TRADING_IN_CONTAINER` (set by the GHA workflow; unset locally) and pick the matching path below.
+Dispatch shape depends on environment. Inspect `$PROJECT_IN_CONTAINER` (set by the GHA workflow; unset locally) and pick the matching path below.
 
 **Throughput vs candidate comparison.** The cap values below assume a *throughput* dispatch pattern — each subagent implements a different track. They do NOT cover "run N candidates against the same problem, pick best." That's a separate mode with its own cap logic; not supported by this orchestrator today.
 
@@ -826,7 +814,7 @@ Dispatch shape depends on environment. Inspect `$TRADING_IN_CONTAINER` (set by t
 - Cap: **2 parallel subagents** per Agent message. Each subagent creates its own jj workspace: `jj workspace add .agents/jj-ws/agent-<short-id> && cd .agents/jj-ws/agent-<short-id>`. Working copy isolation is provided by jj itself (independent `@` per workspace); the underlying commit store is shared, so pushes land on the main jj repo.
 - Cleanup: each subagent prompt ends with `jj workspace forget <name>` (on success or failure — the prompt wraps it in a trap so a mid-flight kill still cleans up).
 
-### GHA (TRADING_IN_CONTAINER=1)
+### GHA (PROJECT_IN_CONTAINER=1)
 
 - Use **git** for VCS (jj is not available in the GHA container).
 - Cap: **2 parallel subagents** per Agent message batch. Each subagent works on a
@@ -843,7 +831,7 @@ Dispatch shape depends on environment. Inspect `$TRADING_IN_CONTAINER` (set by t
   state from a prior sequential agent does not carry over because each subagent
   starts with a fresh checkout command.
 
-Do NOT set `isolation: "worktree"` on the Agent tool in either path. Local uses `jj workspace add`; GHA doesn't need isolation at all. Mixing git-worktree with jj caused the 2026-04-15 "worktree has no .jj/" failure; mixing at all is the confusion source we're fixing.
+Do NOT set `isolation: "worktree"` on the Agent tool in either path. Local uses `<vcs_workspace_add>`; GHA doesn't need isolation at all. Mixing git-worktree with other VCS models is the confusion source we're fixing.
 
 **Parallel write conflict policy**: parallel feat-agents must not write to any shared file.
 The files `dev/decisions.md`, `CLAUDE.md`, and `docs/design/*.md` are read-only during
@@ -861,7 +849,7 @@ You are implementing the <FEATURE> track for the <PROJECT_NAME>.
 ## Pre-flight context (read this before starting any work)
 
 ### Current test failures in your test directory
-<paste dune runtest output for this feature's test dir, or "All passing" if clean>
+<paste <test_cmd> output for this feature's test dir, or "All passing" if clean>
 
 ### Last QC review findings
 <paste relevant sections from dev/reviews/<feature>.md, or "No prior review" if first run>
@@ -873,19 +861,18 @@ You are implementing the <FEATURE> track for the <PROJECT_NAME>.
 
 Read these files first:
 1. docs/design/eng-design-<N>-<name>.md  ← your primary design doc
-2. docs/design/weinstein-trading-system-v2.md  ← system context
+2. docs/design/<SYSTEM_CONTEXT_DOC>.md  ← system context
 3. docs/design/codebase-assessment.md  ← what already exists
-4. CLAUDE.md  ← code patterns, OCaml idioms, test patterns, workflow
+4. CLAUDE.md  ← code patterns, project idioms, test patterns, workflow
 5. dev/decisions.md  ← human guidance
 6. dev/status/<feature>.md  ← pick up where you left off
-
+ 
 Your branch: feat/<feature>
-
-  # LOCAL path (TRADING_IN_CONTAINER unset) — isolated jj workspace:
+ 
+  # LOCAL path (PROJECT_IN_CONTAINER unset) — isolated VCS workspace:
   WS_NAME="agent-<your-short-id>"
-  jj workspace add ".agents/jj-ws/$WS_NAME"
-  trap "cd /abs/repo/root && jj workspace forget \"$WS_NAME\" 2>/dev/null || true" EXIT
-  cd ".agents/jj-ws/$WS_NAME"
+  <TODO: Add your project-specific VCS checkout commands here>
+  cd ".agents/vcs-ws/$WS_NAME"
   jj git fetch
   jj new feat/<feature>@origin
   # If bookmark doesn't exist yet: jj bookmark create feat/<feature> -r @
@@ -896,10 +883,10 @@ Your branch: feat/<feature>
   # No workspace / worktree cleanup required.
 
 Work using TDD (CLAUDE.md workflow):
-  1. .mli interface + skeleton → dune build passes
+  1. Interface + skeleton → <build_cmd> passes
   2. Write tests
-  3. Implement → dune build && dune runtest passes
-  4. dune fmt
+  3. Implement → <build_cmd> && <test_cmd> passes
+  4. <format_cmd>
   5. Commit and push (see commit discipline below)
 
 Build/test:
@@ -910,10 +897,10 @@ COMMIT DISCIPLINE — this is critical for reviewability AND for surviving rate-
   - Target 200–300 lines per commit (absolute max 400 including tests)
   - Never batch multiple modules into one commit
   - Commit sequence per module:
-      a. .mli + skeleton (dune build passes) → commit
+      a. Interface + skeleton (<build_cmd> passes) → commit
       b. tests (mostly failing) → commit
-      c. implementation (dune build && dune runtest passes) → commit
-      d. dune fmt → commit if it changed anything
+      c. implementation (<build_cmd> && <test_cmd> passes) → commit
+      d. <format_cmd> → commit if it changed anything
   - Each commit must build and (where possible) pass tests on its own
   - Push after every commit:
       jj describe -m "commit message"
@@ -922,22 +909,17 @@ COMMIT DISCIPLINE — this is critical for reviewability AND for surviving rate-
   - **Open a DRAFT PR as soon as the first real commit is pushed** — do
     not wait until session end. If the session is killed mid-flight
     (rate-limit, timeout), at least the PR exists with whatever was
-    pushed. Use jst to open the PR (jst is on PATH in trading-devcontainer):
-      GH_TOKEN=$GH_TOKEN jst submit feat/<feature>
+    pushed. Use `<vcs_submit_tool>` to open the PR:
+      `<vcs_submit_cmd>`
     Subsequent pushes update the PR automatically (same branch).
     If jst is not available, use the URL printed by `jj git push`:
       remote: Create a pull request for '<branch>' on GitHub by visiting:
       remote:      https://github.com/dayfine/trading/pull/new/<branch>
-  - At session end, mark the PR ready for review:
-      GH_TOKEN=$GH_TOKEN jst submit feat/<feature>
-    jst is on PATH in the orchestrator runtime (trading-devcontainer image
-    + dev/run.sh). If GH_TOKEN isn't set, jst will fail with a clear error
-    and the branch is still pushed — the orchestrator's Step 4.5 will
-    retry PR creation via the curl fallback.
+  - At session end, mark the PR ready for review via `<vcs_submit_cmd>`.
 
 MAX ITERATIONS — build-fix cycles:
   - If you have attempted 3 consecutive build-fix cycles without passing
-    dune build && dune runtest, stop immediately.
+    <build_cmd> && <test_cmd>, stop immediately.
   - Report your partial state and the specific blocker.
   - Do not attempt a 4th cycle — let the orchestrator decide (retry vs. escalate).
 
@@ -945,12 +927,12 @@ Do as much meaningful work as you can in one session.
 Stop at a natural boundary (a passing build, a completed module).
 
 CRITICAL — before returning, do all of these (in this order, so a kill during the last step still leaves the PR open):
-  1. Ensure dune build && dune runtest passes **on a clean checkout** of your branch (your worktree is isolated, so this is the local state — but verify nothing relies on files from sibling subagents' workspaces; only content tracked in your commits should matter)
+  1. Ensure <build_cmd> && <test_cmd> passes **on a clean checkout** of your branch.
   2. All changes committed and pushed (nothing uncommitted)
-  3. Draft PR already open from first push (see commit discipline); if not, open it now via `GH_TOKEN=$GH_TOKEN jst submit feat/<feature>`
+  3. Draft PR already open from first push (see commit discipline); if not, open it now via `<vcs_submit_cmd>`
   4. Update dev/status/<feature>.md (status, interface-stable, completed, in-progress, next-steps, commits)
-  5. Do NOT edit dev/status/_index.md — I (the orchestrator) reconcile it in Step 5.5. Editing it from a feature PR collides with every sibling PR touching the same row. Exception: if this PR introduces a brand-new tracked work item (new status file), add the corresponding row to _index.md in this PR — I can't invent one.
-  6. If all work is done and tests pass: mark the PR ready for review via `GH_TOKEN=$GH_TOKEN jst submit feat/<feature>`, and set status to READY_FOR_REVIEW in the status file
+  5. Do NOT edit dev/status/_index.md — I (the orchestrator) reconcile it in Step 5.5.
+  6. If all work is done and tests pass: mark the PR ready for review via `<vcs_submit_cmd>`, and set status to READY_FOR_REVIEW in the status file
 
 <FEATURE-SPECIFIC CONSTRAINT IF ANY>
 
@@ -977,9 +959,9 @@ This is maintenance work, not feature development.
 <list specific files>
 
 ### Expected quality improvement
-<what improves: e.g., "eliminates duplication of _compute_ma_slope across 3 modules",
- "reduces cyclomatic complexity of _classify_new_stage from 12 to <6",
- "establishes canonical state machine shape in engineering-principles.md">
+<what improves: e.g., "eliminates duplication of X across 3 modules",
+ "reduces cyclomatic complexity of Y from 12 to <6",
+ "establishes canonical shape in engineering-principles.md">
 
 ### Constraints
 - Do NOT add new features or change external interfaces
@@ -989,8 +971,7 @@ This is maintenance work, not feature development.
   not rewrite)
 
 Your branch: refactor/<short-name>
-  jj new main@origin
-  jj bookmark create refactor/<short-name> -r @
+  <TODO: Add your project-specific VCS checkout commands for refactors here>
 
 Same build/test/commit discipline as feature work. Same MAX ITERATIONS cap (3).
 When done: set a new status entry in the relevant dev/status/<feature>.md marking
@@ -1032,7 +1013,7 @@ the orchestrator will cap the loop and the PR will stay draft until the next run
 
 ### Commit discipline
 - Use commit subject prefix `fix(review): ` so the audit trail is greppable.
-  Example: `fix(review): address QC rework iteration 1 — stage classifier .mli docs + magic-number extraction`.
+  Example: `fix(review): address QC rework iteration 1 — <DESCRIPTION>`.
 - Each fix commit should be small and targeted. Do not squash unrelated fixes.
 - Push after every commit (same discipline as normal dispatch).
 
@@ -1048,8 +1029,8 @@ Your branch: feat/<feature> (already exists — do not recreate).
 - Touch tracks other than <FEATURE>.
 
 ### Acceptance check before returning
-- `dune build && dune runtest` passes clean on your branch.
-- `dune build @fmt` passes.
+- `<build_cmd> && <test_cmd>` passes clean on your branch.
+- `<format_cmd>` passes.
 - Every checked-fail item in dev/reviews/<feature>.md has either a code change
   addressing it OR a note in your return value explaining why you did not change
   code.
@@ -1059,9 +1040,7 @@ any findings you did not address with reasons. Do not re-summarize the entire
 implementation — the orchestrator already has that context.
 ```
 
-**Notes for the orchestrator when dispatching Rework mode:**
-
-- Use the same subagent isolation model as the normal dispatch (jj workspace locally, plain git in GHA).
+- Use the same subagent isolation model as the normal dispatch.
 - Re-use the same branch `feat/<feature>` — the rework dispatches push additional commits on top of the existing PR, so the draft PR updates in place.
 - After the feat-agent returns, **re-run Step 5's QC pipeline on the new tip SHA** (Stage 1 + Stage 2 + Combined result). Stage 4 (audit) writes a fresh record with the new iteration number.
 - Then loop back to Step 5a for the next decision.
@@ -1081,19 +1060,19 @@ Recovery flow:
 ```bash
 # For each branch the subagent reported pushing:
 # gh is not available in the devcontainer — use curl against the REST API.
-REPO="${GITHUB_REPOSITORY:-dayfine/trading}"
+REPO="${GITHUB_REPOSITORY:-<OWNER>/<REPO>}"
 OWNER="${REPO%/*}"
 PR_COUNT=$(curl -sSL \
   -H "Authorization: Bearer ${GH_TOKEN}" \
   -H "Accept: application/vnd.github+json" \
   "https://api.github.com/repos/${REPO}/pulls?head=${OWNER}:<branch>&state=open" \
   | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-[ "$PR_COUNT" -eq 0 ] && GH_TOKEN=$GH_TOKEN jst submit <branch>
+[ "$PR_COUNT" -eq 0 ] && <vcs_submit_cmd> <branch>
 ```
 
-If jst still fails, surface the branch + jst error in the daily summary
+If `<vcs_submit_tool>` still fails, surface the branch + error in the daily summary
 under §Escalations with the GitHub PR-creation URL:
-  https://github.com/dayfine/trading/pull/new/<branch>
+  https://github.com/PR_NEW_URL/<branch>
 so the human can open the PR manually with one click. Don't loop on it.
 
 This catches the "agent pushed branch but no PR" gap that would
@@ -1117,15 +1096,15 @@ Review the feature: <FEATURE>
 Branch: feat/<feature>
 
 Steps:
-1. jj git init --colocate 2>/dev/null || true && jj git fetch && jj new feat/<feature>@origin
+1. <TODO: Add your project-specific VCS checkout commands for QC here>
 2. Run hard gates (via dev/lib/run-in-env.sh):
-   - dune build @fmt
-   - dune build
-   - dune runtest
-3. Read diff: jj diff --from main@origin --to feat/<feature>@origin
+   - <format_cmd>
+   - <build_cmd>
+   - <test_cmd>
+3. Read diff: <vcs_diff_cmd>
 4. Fill in your structural checklist (see your agent definition in .agents/agents/qc-structural.md)
 5. Capture the tip SHA of the branch being reviewed:
-     REVIEWED_SHA=$(jj log -r 'feat/<feature>@origin' -T 'commit_id' --no-graph)
+     REVIEWED_SHA=$(<vcs_get_tip_sha_cmd>)
    Write this as the FIRST line of dev/reviews/<feature>.md:
      Reviewed SHA: <sha>
    This line enables idempotency: subsequent orchestrator runs compare this SHA to
@@ -1148,8 +1127,8 @@ Branch: feat/<feature>
 Structural QC: APPROVED (you may proceed)
 
 Steps:
-1. Read docs/design/weinstein-book-reference.md (your primary authority)
-2. Read the relevant eng-design-<N>-*.md for this feature
+1. Read docs/design/<AUTHORITY_DOC>.md (your primary authority)
+2. Read the relevant design docs for this feature
 3. Read the implementation files from the feature branch
 4. Fill in your behavioral checklist (see your agent definition in .agents/agents/qc-behavioral.md)
 
@@ -1188,7 +1167,7 @@ GitHub's REST API does not expose a draft→ready endpoint. Use the GraphQL
 
 ```bash
 PR_NUMBER="<the PR number from Stage 1/2 QC output>"
-REPO="${GITHUB_REPOSITORY:-dayfine/trading}"
+REPO="${GITHUB_REPOSITORY:-<OWNER>/<REPO>}"
 
 # 1. Look up the PR's GraphQL node_id via REST (cheap).
 NODE_ID="$(curl -sSL \
@@ -1238,7 +1217,7 @@ DATE="$(date +%Y-%m-%d)"
 FEATURE="<feature>"
 BRANCH="feat/<feature>"   # or harness/<name> for harness work
 
-bash trading/devtools/checks/record_qc_audit.sh "$FEATURE" "$BRANCH" "$DATE"
+bash dev/lib/record_qc_audit.sh "$FEATURE" "$BRANCH" "$DATE"
 ```
 
 The script extracts from `dev/reviews/<feature>.md`:
@@ -1268,7 +1247,7 @@ awk '
 **Fallback** — if `record_qc_audit.sh` fails (missing review file, no verdict),
 call `write_audit.sh` directly with explicit flags:
 ```bash
-bash trading/devtools/checks/write_audit.sh \
+bash dev/lib/write_audit.sh \
   --date "$DATE" \
   --feature "$FEATURE" \
   --branch "$BRANCH" \
@@ -1413,7 +1392,7 @@ For each row in `dev/status/_index.md`:
 3. Compare against the row:
    - **Status** — must match the (possibly just-updated) `## Status` heading value (IN_PROGRESS / READY_FOR_REVIEW / MERGED / APPROVED / BLOCKED).
    - **Owner** — must match `## Ownership` (or be `—` if the track has no active owner).
-   - **Open PR(s)** — cross-reference against the GitHub REST API (via `curl -sSL -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY:-dayfine/trading}/pulls?state=open"`) filtered to that track's branches; each currently-open PR targeting main that carries this track's work should appear. Merged PRs must not appear in this column.
+   - **Open PR(s)** — cross-reference against the GitHub REST API (via `curl -sSL -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY:-<OWNER>/<REPO>}/pulls?state=open"`) filtered to that track's branches; each currently-open PR targeting main that carries this track's work should appear. Merged PRs must not appear in this column.
    - **Next task** — must be the top item from `## Next Steps` (or an equivalent synthesis of the most concrete pending item). For MERGED rows, use `—` plus a short parenthetical noting the merge date + PR number.
 4. If any cell drifts, fix it. Do not touch unrelated rows.
 5. Update the `Last updated:` line to today's date **at the end of Step 5.5**, not earlier — the timestamp must reflect the reconcile, not whatever the last feature agent happened to write.
@@ -1439,7 +1418,7 @@ a ghost finding). Deterministic checks are cheaper, faster, and don't hallucinat
 ### Step 6.1: Build gate
 
 ```bash
-dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest
+dev/lib/run-in-env.sh <build_cmd> && dev/lib/run-in-env.sh <test_cmd>
 BUILD_EXIT=$?
 echo "build-gate exit=$BUILD_EXIT"
 ```
@@ -1455,7 +1434,7 @@ this doc was wrong). Trust only `BUILD_EXIT`.
 - Exit non-zero → FAILING. Surface in `## Escalations` as:
 
   ```
-  [critical] Main baseline RED — dune runtest exit <N>. Evidence:
+  [critical] Main baseline RED — <test_cmd> exit <N>. Evidence:
   <paste the last ~20 lines of output, including failing rule name and exit code>
   ```
 
@@ -1472,7 +1451,7 @@ this doc was wrong). Trust only `BUILD_EXIT`.
 ### Step 6.2: Status file integrity check
 
 ```bash
-dev/lib/run-in-env.sh sh trading/devtools/checks/status_file_integrity.sh
+dev/lib/run-in-env.sh sh dev/lib/status_file_integrity.sh
 INTEGRITY_EXIT=$?
 echo "status-integrity exit=$INTEGRITY_EXIT"
 ```
@@ -1595,7 +1574,7 @@ the track being skipped; put the cross-track reason in Notes.
 **Measured cost (from GHA execution file):** Check if `dev/budget/<today>-run<N>.json`
 exists (written by the GHA "Capture run cost" step after this run ends). If it exists:
   - Total (measured from API usage): $<total_cost_usd from JSON> / $<cap> (<pct>%)
-  - Measurement: `total_cost_usd` from `claude-code-action` execution_file — covers all
+  - Measurement: `total_cost_usd` from execution_file — covers all
     subagents spawned by this orchestrator (Agent tool calls included)
   - Per-subagent breakdown: not available from action output (see dev/status/cost-tracking.md)
   - Cache utilization: not available (token counts not surfaced by action)
@@ -1647,15 +1626,13 @@ M? — <name> — requires: ...
 (List any escalation flags raised during this run — these require human decision)
 
 **Live-evidence rule for `[critical]` build/linter assertions:** Before writing
-a `[critical]` line that claims `dune build`, `dune runtest`, or a named linter
+a `[critical]` line that claims `<build_cmd>`, `<test_cmd>`, or a named linter
 is RED on main, you MUST have run the check in this session and must paste the
 tail of the output (last ~20 lines, including the failing rule name and exit code)
 into the escalation body:
 
-    [critical] Main baseline RED on `dune runtest trading/devtools --force`. Evidence:
+    [critical] Main baseline RED on `<test_cmd>`. Evidence:
       ```
-      OK: nesting linter ...
-      FAIL: magic_numbers — <filename>:<line>: ...
       ...
       exit=1
       ```
@@ -1699,10 +1676,9 @@ BASENAME="$(basename "$SUMMARY_FILE" .md)"       # e.g. 2026-04-16 or 2026-04-16
 BRANCH="ops/${BASENAME/#/daily-}"                # → ops/daily-2026-04-16[-runN]
 
 git config user.email "noreply@github.com"
-git config user.name "claude-orchestrator"
+git config user.name "ai-orchestrator"
 
-jj bookmark set "$BRANCH" -r @
-jj git push -b "$BRANCH" --allow-new
+<TODO: Add your project-specific VCS push commands here>
 ```
 
 Then open the PR via curl (the devcontainer has no `gh`):
@@ -1796,7 +1772,7 @@ summary PR on a consolidation failure.
 
 Pause automation and flag for human review in the daily summary when:
 - Any QC NEEDS_REWORK on the same feature for 3+ consecutive runs (design problem, not an implementation problem). With intra-run rework (Step 5a) this now means 3+ consecutive runs where the track exits Step 5a via `cap_hit` or `budget_hold` without reaching APPROVED — a single run already absorbs up to `rework_cap_per_run` iterations.
-- A feat-agent proposes modifying an existing core module (Portfolio, Orders, Position, Strategy, Engine) rather than building alongside
+- A feat-agent proposes modifying an existing core module rather than building alongside
 - A behavioral QC finding indicates a requirement is ambiguous or missing from the design doc
 - A new architectural decision is needed not covered by existing design docs
 
@@ -1804,4 +1780,5 @@ Pause automation and flag for human review in the daily summary when:
 
 ## Dependency tracking
 
-Watch for "Interface stable: YES" in status files. When data-layer goes stable, note that screener is now unblocked. When all three (data-layer, portfolio-stops, screener) go stable, note that simulation is unblocked.
+Watch for "Interface stable: YES" in status files. When a core module goes stable, note what's unblocked.
+

--- a/.agents/agents/qc-behavioral.md
+++ b/.agents/agents/qc-behavioral.md
@@ -1,19 +1,16 @@
 ---
 name: qc-behavioral
-description: Behavioral correctness QC reviewer. For every non-trivial contract the code claims — in module docstrings, `.mli` comments, PR body "Test plan"/"What it does" sections, or the feature plan file — verifies the test suite pins that claim. Project-specific authority + domain checklist live in `.agents/rules/qc-behavioral-authority.md`. Only runs after qc-structural APPROVED.
 model: opus
-harness: reusable
+harness: template
 ---
 
-You are the **QC Behavioral Reviewer**. You check behavioral correctness — whether the implementation faithfully delivers on the contracts it claims. The contracts come from the module's own docstrings, its `.mli` comments, the feature plan file, the PR body's "Test plan" / "What it does" sections, and (for domain features) the project's authority documents.
+You are the **QC Behavioral Reviewer**. You check behavioral correctness — whether the implementation faithfully delivers on the contracts it claims. The contracts come from the module's own docstrings, its documentation comments, the feature plan file, the PR body's "Test plan" / "What it does" sections, and (for domain features) the project's authority documents.
 
 You do NOT check code style, formatting, or architecture patterns; those are qc-structural's responsibility. But you are responsible for every PR's behavioral correctness, not just those that touch domain-specific logic.
 
 **Project-specific augmentation lives at `.agents/rules/qc-behavioral-authority.md`.** Read it after the generic Contract Pinning Checklist (CP1–CP4): it carries the project's authority document hierarchy (e.g. domain reference docs) and the domain-specific checklist rows that get appended for domain-feature PRs.
 
-## VCS choice (automatic)
-
-If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available.
+If `$PROJECT_IN_CONTAINER` is set (GHA runs), use **git**.
 
 **Critical — GHA working-tree isolation:** The orchestrator and all QC subagents share a single git working tree on GHA. To read the feature branch content without moving the working tree off main, use a **detached HEAD** checkout:
 
@@ -37,7 +34,7 @@ REVIEW_FILE="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}/dev/reviews/<
 
 Using `${GITHUB_WORKSPACE}` ensures the file lands in the orchestrator's working tree regardless of which SHA the agent currently has detached. Do NOT commit or push. The orchestrator reads the file directly from the filesystem after the subagent returns.
 
-Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.agents/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
+Otherwise (local runs), follow the orchestrator's dispatch prompt for the exact commands. See `.agents/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
 
 ## Allowed tools
 
@@ -53,12 +50,11 @@ If qc-structural flagged **A1** (core module modification), you must evaluate th
 
 For **domain features**: see the per-project authority hierarchy in
 `.agents/rules/qc-behavioral-authority.md`. The hierarchy is project-specific
-(e.g. for the Weinstein Trading System, the primary authority is
-`docs/design/weinstein-book-reference.md`).
+(e.g. for the <PROJECT_NAME>, the primary authority is
+`docs/design/<AUTHORITY_DOC>.md`).
 
-For **infrastructure, library, refactor, or harness PRs** — generic across
-projects:
-- The new module's `.mli` docstrings — the primary contract for what the module does
+For **infrastructure, library, refactor, or harness PRs** — generic across projects:
+- The new module's documentation comments — the primary contract for what the module does
 - The feature plan file (e.g. `dev/plans/<feature>.md`) — the agreed design spec
 - The PR body's "Test plan" / "Test coverage" / "What it does" sections — the author's explicit claims about what the PR delivers
 
@@ -78,7 +74,7 @@ Note: `dev/reviews/<feature>.md` starts with a `Reviewed SHA:` line pinned by qc
 
 ### Step 3: Fill in the checklists
 
-Fill the **Contract Pinning Checklist** (CP1–CP4) first — it applies to every PR regardless of subsystem. Read the PR body, the new `.mli` files, and the test files in the diff to verify each claim. Then fill the project's **Behavioral Checklist** rows (defined in `.agents/rules/qc-behavioral-authority.md` — typically domain-specific gates like stage classification, stop rules, or screener cascade for a trading project). Every claim must be traceable to a specific section of the authority document. Use Grep to find the implementation evidence.
+Fill the **Contract Pinning Checklist** (CP1–CP4) first — it applies to every PR regardless of subsystem. Read the PR body, the new interface/documentation, and the test files in the diff to verify each claim. Then fill the project's **Behavioral Checklist** rows (defined in `.agents/rules/qc-behavioral-authority.md`). Every claim must be traceable to a specific section of the authority document. Use Grep to find the implementation evidence.
 
 ### Step 4: Assign a quality score
 
@@ -100,7 +96,7 @@ After filling the checklist, assign a quality score (1–5) with a brief rationa
 
 ## Contract Pinning Checklist
 
-This section applies to **every PR**, regardless of subsystem. Fill it before the project's domain-specific rows (in `.agents/rules/qc-behavioral-authority.md`). NA is only valid for CP1 when no new `.mli` is added; CP2 NA when the PR body has no "Test plan" / "Test coverage" section; CP3/CP4 NA when no pass-through or guarded behavior exists.
+This section applies to **every PR**, regardless of subsystem. Fill it before the project's domain-specific rows (in `.agents/rules/qc-behavioral-authority.md`). NA is only valid for CP1 when no new interface/docs are added; CP2 NA when the PR body has no "Test plan" / "Test coverage" section; CP3/CP4 NA when no pass-through or guarded behavior exists.
 
 Any CP* FAIL is a FAIL for overall verdict — same mechanical rule as the project's domain rows.
 
@@ -109,25 +105,14 @@ Any CP* FAIL is a FAIL for overall verdict — same mechanical rule as the proje
 
 | # | Check | Status | Notes |
 |---|-------|--------|-------|
-| CP1 | Each non-trivial claim in new .mli docstrings has an identified test that pins it | PASS/FAIL/NA | List (claim → test name) pairs. NA only if no new .mli added. |
+| CP1 | Each non-trivial claim in new documentation comments has an identified test that pins it | PASS/FAIL/NA | List (claim → test name) pairs. NA only if no new docs added. |
 | CP2 | Each claim in PR body "Test plan"/"Test coverage" sections has a corresponding test in the committed test file | PASS/FAIL/NA | List PR-body claims and test names that satisfy them. FAIL if PR body advertises a test that does not exist in the file. |
 | CP3 | Pass-through / identity / invariant tests pin identity (elements_are [equal_to ...] or equal_to on entire value), not just size_is | PASS/FAIL/NA | Any test whose contract is "output equals input" but only asserts element count is FAIL. NA if no pass-through semantics in this feature. |
-| CP4 | Each guard called out explicitly in code docstrings has a test that exercises the guarded-against scenario | PASS/FAIL/NA | List (guard claim → test name) pairs. FAIL if the docstring names an edge case but no test covers it. NA if no explicit guard claims in new code. |
+| CP4 | Each guard called out explicitly in code documentation has a test that exercises the guarded-against scenario | PASS/FAIL/NA | List (guard claim → test name) pairs. FAIL if the docs name an edge case but no test covers it. NA if no explicit guard claims in new code. |
 ```
 
-### CP2 worked example — PR #478
-
-PR #478 (`feat(backtest): 3f-part3 tiered runner Friday cycle + per-transition bookkeeping`) was approved by both QC agents. The PR body's "Test coverage" section advertised:
-- "multi-symbol `CreateEntering` scenario"
-- "symbol re-entering under a new `position_id` (regression guard for `_is_newly_closed`)"
-
-Neither test existed in `trading/trading/backtest/test/test_runner_tiered_cycle.ml` at the approved SHA. CP2 would have caught this:
-
-```
-| CP2 | PR body claims vs committed tests | FAIL | PR body advertises "multi-symbol CreateEntering" and "symbol recycle under new position_id" — neither test found in test_runner_tiered_cycle.ml. Required fix: add both tests or remove the claims from the PR body. |
-```
-
-CP2 FAIL → NEEDS_REWORK. The review would have blocked the merge until the tests were added (or the claims were retracted).
+### CP2 worked example
+<TODO: Add your project-specific examples here>
 
 ---
 
@@ -186,7 +171,7 @@ Append your behavioral checklist to the existing `dev/reviews/<feature>.md` writ
 
 **IMPORTANT: Do NOT push your changes to origin.** The review file is written in-place in your worktree for the lead-orchestrator to read directly. Pushing creates orphan `dev/reviews/*` branches on origin that accumulate as clutter. Write the file and return — the orchestrator reads your output text and the file you wrote.
 
-Write the review file using the Edit/Write tool (do not run jj or git push):
+Write the review file using the Edit/Write tool:
 
 ```markdown
 ---
@@ -222,25 +207,23 @@ Return the overall verdict (APPROVED / NEEDS_REWORK), the quality score (1–5),
 ## Example: filled checklist (NEEDS_REWORK, illustrative)
 
 The project-specific rows below come from `.agents/rules/qc-behavioral-authority.md`.
-The exact rows vary per project. The illustration below uses the rows the
-current Weinstein Trading System project appends; see the authority file
-for the same example fully filled in.
-
+The exact rows vary per project.
+ 
 ```
 ## Quality Score
-
-2 — Wrong MA period is a fundamental domain parameter error; otherwise clean implementation.
-
+ 
+2 — <rationale>
+ 
 ## Verdict
-
+ 
 NEEDS_REWORK
-
+ 
 ## NEEDS_REWORK Items
-
-### <project-specific row>: Wrong moving average period in stage classifier
-- Finding: Stage classifier uses 20-week MA for the primary trend line; the project's authority document specifies 30-week MA.
-- Location: <path>/<file>.ml, line 34
-- Authority: <quote from project authority doc>
-- Required fix: Change ma_period from 20 to 30 weeks (must come from config, not hardcoded)
-- harness_gap: LINTER_CANDIDATE — a golden scenario test with known input and 30-week MA window would catch this deterministically.
+ 
+### <project-specific row>: <finding>
+- Finding: <description>
+- Location: <location>
+- Authority: <quote>
+- Required fix: <fix>
+- harness_gap: LINTER_CANDIDATE
 ```

--- a/.agents/agents/qc-structural.md
+++ b/.agents/agents/qc-structural.md
@@ -1,8 +1,7 @@
 ---
 name: qc-structural
-description: Structural and mechanical QC reviewer. Checks build health, code patterns, and architecture constraints. Runs before qc-behavioral — if this agent FAILs, behavioral review does not run. Project-specific architecture rules live in `.agents/rules/qc-structural-authority.md`.
 model: haiku
-harness: reusable
+harness: template
 ---
 
 You are the **QC Structural Reviewer**. You check structural and mechanical correctness only — you do not evaluate domain behavior. That is qc-behavioral's responsibility.
@@ -11,7 +10,7 @@ You are the **QC Structural Reviewer**. You check structural and mechanical corr
 
 ## VCS choice (automatic)
 
-If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available.
+If `$PROJECT_IN_CONTAINER` is set (GHA runs), use **git**.
 
 **Critical — GHA working-tree isolation:** The orchestrator and all QC subagents share a single git working tree on GHA. To read the feature branch content without moving the working tree off main, use a **detached HEAD** checkout:
 
@@ -35,7 +34,7 @@ REVIEW_FILE="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}/dev/reviews/<
 
 Using `${GITHUB_WORKSPACE}` ensures the file lands in the orchestrator's working tree regardless of which SHA the agent currently has detached. Do NOT commit or push. The orchestrator reads the file directly from the filesystem after the subagent returns.
 
-Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.agents/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
+Otherwise (local runs), follow the orchestrator's dispatch prompt for the exact commands. See `.agents/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
 
 ## Allowed tools
 
@@ -51,19 +50,9 @@ You check: build health, format compliance, code patterns, architecture constrai
 
 ### Step 1: Checkout the feature branch (read-only)
 
-```bash
-jj git init --colocate 2>/dev/null || true
-jj git fetch
-jj new feat/<feature-name>@origin   # read-only — do NOT write files here
-```
+<TODO: Add your project-specific VCS checkout commands for QC here>
 
-After fetching, check staleness — how many commits is `main@origin` ahead of this branch's
-merge base? Run:
-
-```bash
-# Count commits on main not reachable from the feature branch
-jj log --revset "main@origin ~ ancestors(feat/<feature-name>@origin)" --no-graph -T "commit_id\n" | wc -l
-```
+After fetching, check staleness — how many commits is the main branch ahead of this branch's merge base? Run `<vcs_log_cmd>`.
 
 If this count is > 10, add a **FLAG** note to the checklist: "Branch is N commits behind
 main@origin — consider rebasing before merge." This is a FLAG, not a FAIL: it does not
@@ -73,20 +62,19 @@ block APPROVED, but the orchestrator escalation policy should note it.
 
 Run each command and record PASS or FAIL with any error output:
 
+Run each command and record PASS or FAIL with any error output:
+
 ```bash
-dev/lib/run-in-env.sh dune build @fmt
-dev/lib/run-in-env.sh dune build
-dev/lib/run-in-env.sh dune runtest
+dev/lib/run-in-env.sh <format_cmd>
+dev/lib/run-in-env.sh <build_cmd>
+dev/lib/run-in-env.sh <test_cmd>
 ```
 
 If any of the three fail, the overall verdict is NEEDS_REWORK immediately. Proceed to fill in the remaining checklist items you can determine from static analysis, then write the output.
 
 ### Step 3: Read the diff
 
-```bash
-jj diff --from main@origin --to feat/<feature-name>@origin --stat
-jj diff --from main@origin --to feat/<feature-name>@origin
-```
+Use `<vcs_diff_cmd>` to read the changes.
 
 ### Step 4: Fill in the structural checklist
 
@@ -97,7 +85,7 @@ Work through each item below. Use Grep and Glob to verify claims — do not gues
 After filling the checklist, capture the tip commit SHA of the feature branch:
 
 ```bash
-REVIEWED_SHA=$(jj log -r 'feat/<feature-name>@origin' -T 'commit_id' --no-graph)
+REVIEWED_SHA=$(<vcs_get_tip_sha_cmd>)
 ```
 
 Write this as the **first line** of `dev/reviews/<feature>.md` before the checklist:
@@ -115,7 +103,7 @@ Do not omit it even on NEEDS_REWORK — the orchestrator needs it regardless of 
 ## Structural Checklist
 
 Use this template exactly. Every item must be one of: `PASS`, `FAIL`, `NA`.
-`NA` is only valid when the item genuinely does not apply (e.g., no new `.mli` files were added).
+`NA` is only valid when the item genuinely does not apply.
 Do not use freeform narrative in the Status column — put detail in the Notes column.
 
 ```
@@ -123,15 +111,15 @@ Do not use freeform narrative in the Status column — put detail in the Notes c
 
 | # | Check | Status | Notes |
 |---|-------|--------|-------|
-| H1 | dune build @fmt (format check) | PASS/FAIL | |
-| H2 | dune build | PASS/FAIL | |
-| H3 | dune runtest | PASS/FAIL | N tests, N passed, N failed |
-| P1 | Functions ≤ 50 lines — covered by language-specific linter (typically a dune runtest gate) | PASS/NA | If H3 passed, this is clean. If H3 failed, check the relevant linter output. |
-| P2 | No magic numbers — covered by language-specific linter | PASS/NA | If H3 passed, this is clean. If H3 failed, check the magic-numbers linter output. |
-| P3 | All configurable thresholds/periods/weights in config record | PASS/FAIL/NA | Broader than P2: verify new tunable values have config fields, not just that literals are absent |
-| P4 | Public-symbol export hygiene — covered by language-specific linter (e.g. `.mli` coverage in OCaml) | PASS/NA | If H3 passed, this is clean. If H3 failed, check the relevant linter output. |
-| P5 | Internal helpers prefixed per project convention | PASS/FAIL/NA | List violations if any (project conventions in `.agents/rules/` + project authority file) |
-| (project-specific rows) | See `.agents/rules/qc-structural-authority.md` — append the rows it specifies (e.g. test-pattern conformance, core-module modification flags, dependency-direction rules) | | |
+| H1 | Format check | PASS/FAIL | |
+| H2 | Build | PASS/FAIL | |
+| H3 | Test run | PASS/FAIL | N tests, N passed, N failed |
+| P1 | Function length compliance | PASS/NA | |
+| P2 | No magic numbers | PASS/NA | |
+| P3 | Configurable thresholds in config record | PASS/FAIL/NA | |
+| P4 | Public-symbol export hygiene | PASS/NA | |
+| P5 | Internal helpers prefixed per project convention | PASS/FAIL/NA | |
+| (project-specific rows) | See `.agents/rules/qc-structural-authority.md` | | |
 
 ## Verdict
 
@@ -156,18 +144,9 @@ APPROVED | NEEDS_REWORK
 
 ## Writing the review file
 
-Write `dev/reviews/<feature>.md` from a clean branch based on `main@origin` — never from the feature branch. The first line of the file must be the `Reviewed SHA:` line captured in Step 5:
+Write `dev/reviews/<feature>.md` from a clean branch based on main — never from the feature branch. The first line of the file must be the `Reviewed SHA:` line captured in Step 5.
 
-```
-Reviewed SHA: <sha captured in Step 5>
-```
-
-Then append the structural checklist below it.
-
-```bash
-jj new main@origin
-jj describe -m "QC structural review: <feature-name>"
-```
+<TODO: Add your project-specific VCS checkout commands for writing reviews here>
 
 Write the file using the Edit/Write tool.
 
@@ -185,28 +164,24 @@ Return the overall verdict (APPROVED / NEEDS_REWORK) and a one-line summary of a
 ---
 
 ## Example: filled checklist (NEEDS_REWORK, illustrative)
-
+ 
 The exact row IDs after P5 vary per project — they come from
-`.agents/rules/qc-structural-authority.md`. The illustration below uses
-the rows the current Weinstein Trading System project appends (P6, A1–A3).
-
+`.agents/rules/qc-structural-authority.md`.
+ 
 ```
 ## Structural Checklist
-
+ 
 | # | Check | Status | Notes |
 |---|-------|--------|-------|
-| H1 | dune build @fmt | PASS | |
-| H2 | dune build | PASS | |
-| H3 | dune runtest | PASS | 42 tests, 42 passed, 0 failed |
-| P1 | Functions ≤ 50 lines (linter) | PASS | fn-length linter passed as part of H3 |
-| P2 | No magic numbers (linter) | FAIL | magic-numbers linter failed (H3): some_module.ml line 87: 0.03 hardcoded |
-| P3 | Config completeness | FAIL | some_module.ml line 87: 0.03 should be config.breakout_threshold |
-| P4 | Public-symbol export hygiene (linter) | PASS | mli-coverage linter passed as part of H3 |
+| H1 | Format check | PASS | |
+| H2 | Build | PASS | |
+| H3 | Test run | PASS | |
+| P1 | Function length compliance | PASS | |
+| P2 | No magic numbers | FAIL | |
+| P3 | Config completeness | FAIL | |
+| P4 | Public-symbol export hygiene | PASS | |
 | P5 | Internal helpers prefixed per convention | PASS | |
-| P6 | Tests conform to project test-patterns rules | PASS | |
-| A1 | Core module modifications | PASS | No modifications to project-defined core modules |
-| A2 | Dependency-direction rules respected | PASS | |
-| A3 | No unnecessary existing module modifications | PASS | |
+```
 
 ## Verdict
 
@@ -214,9 +189,9 @@ NEEDS_REWORK
 
 ## NEEDS_REWORK Items
 
-### P2/P3: Magic number in some_module.ml
-- Finding: Numeric literal 0.03 used directly in detection logic; not routed through config record. Caught by magic-numbers linter (H3 failure).
-- Location: <path>/some_module.ml line 87
-- Required fix: Add breakout_threshold field to the config record; reference config.breakout_threshold here
-- harness_gap: ONGOING_REVIEW — P3 (config completeness) still requires judgment: is this a tunable parameter or an implementation constant?
+### P2/P3: Magic number in some_module.ext
+- Finding: Numeric literal used directly in logic.
+- Location: <path>/<file> line 87
+- Required fix: Route through config
+- harness_gap: ONGOING_REVIEW
 ```

--- a/.agents/rules/worktree-isolation.md
+++ b/.agents/rules/worktree-isolation.md
@@ -1,5 +1,5 @@
 ---
-harness: reusable
+harness: template
 ---
 
 # Worktree Isolation Integrity
@@ -14,7 +14,7 @@ branches.
 
 Consequences observed in practice:
 
-1. **File leaks.** `jj new main@origin` can leave stray modifications in the
+1. **File leaks.** VCS operations can leave stray modifications in the
    working copy that originated in a sibling agent's branch, which then get
    auto-snapshotted into your commit.
 2. **Ancestry leaks.** If your `@` is a descendant of another agent's
@@ -22,7 +22,7 @@ Consequences observed in practice:
    `main` will include those commits too — even if your single commit only
    touches the files you intended.
 
-Both happened on 2026-04-16 while concurrent feat-weinstein and
+Both happened on 2026-04-16 while concurrent feature and
 harness-maintainer agents were running.
 
 ## The rule
@@ -34,29 +34,28 @@ not on a sibling agent's stack.
 **Pre-commit checks:**
 
 ```bash
-jj diff --stat   # expect only files listed in your task's "Files to touch"
+<vcs_diff_stat_cmd>   # expect only files listed in your task's "Files to touch"
 ```
 
 If stray files appear, scrub them before staging your real changes:
 
 ```bash
-jj restore <stray-path> --from main@origin
+<vcs_restore_cmd> <stray-path>
 ```
 
 **Pre-push checks:**
 
 ```bash
-# What commits are in your branch but not in main@origin?
-jj log -r '::<your-bookmark> & ~::main@origin' --no-graph -T 'description.first_line() ++ "\n"'
+# What commits are in your branch but not in main?
+<vcs_log_branch_cmd>
 ```
 
-You should see **only your own commits**. If you see commits from other agents
-(e.g., `feat(stops):`, `feat(strategy):`), your branch is stacked on top of
-their work. Rebase onto `main@origin`:
+You should see **only your own commits**. If you see commits from other agents,
+your branch is stacked on top of their work. Rebase onto main:
 
 ```bash
-jj rebase -r <your-change-id> -d main@origin --ignore-immutable
-jj git push -b <your-bookmark>   # force-update if remote diverges
+<vcs_rebase_cmd>
+<vcs_push_cmd>   # force-update if remote diverges
 ```
 
 **Post-push verification (when task allows network access):**
@@ -74,12 +73,12 @@ force-push — do not hand off a contaminated PR for review.
   known to be running in the same repo.
 - Any session where the dispatcher's pre-flight prompt calls out workspace
   contamination risk explicitly.
-- Any time `jj diff --stat` surprises you at dispatch time.
+- Any time `<vcs_diff_stat_cmd>` surprises you at dispatch time.
 
 ## What this rule does NOT cover
 
 - Shared-worktree dispatch (non-isolated) — that's a different hazard class
   (`@` collisions between parent and child). Use `isolation: "worktree"` plus
   this rule for most concurrent work.
-- Git-mode dispatch inside `$TRADING_IN_CONTAINER` (GHA) — CI runners start
-  from a fresh checkout, so contamination doesn't occur there.
+- Git-mode dispatch inside containers — CI runners start from a fresh
+  checkout, so contamination doesn't occur there.

--- a/bin/agent-harness
+++ b/bin/agent-harness
@@ -1,4 +1,5 @@
 #!/bin/sh
+# harness: reusable
 # agent-harness — scaffolding CLI for the Claude Code orchestration harness.
 #
 # Usage:
@@ -51,13 +52,14 @@ cmd_init() {
   echo "Bootstrapping agent-harness in $target..."
   
   # 1. Create directories
-  mkdir -p "$target/.agents/agents" "$target/.agents/rules" "$target/dev/lib" "$target/.github/workflows" "$target/.claude"
+  mkdir -p "$target/.agents/agents" "$target/.agents/rules" "$target/dev/lib" "$target/.github/workflows" "$target/.claude" "$target/bin"
   
   # 2. Copy files
   cp "$HARNESS_ROOT/.agents/agents/"*.md "$target/.agents/agents/"
   cp "$HARNESS_ROOT/.agents/rules/"*.md "$target/.agents/rules/"
   cp "$HARNESS_ROOT/.github/workflows/"*.yml "$target/.github/workflows/"
   cp "$HARNESS_ROOT/dev/lib/"*.sh "$target/dev/lib/"
+  cp "$HARNESS_ROOT/bin/agent-harness-check.sh" "$target/bin/"
   cp "$HARNESS_ROOT/dev/agent-feature-workflow.md" "$target/dev/"
   cp "$HARNESS_ROOT/dev/agent-feature-workflow-example.md" "$target/dev/"
   cp "$HARNESS_ROOT/.claude/settings.json" "$target/.claude/"

--- a/bin/agent-harness-check.sh
+++ b/bin/agent-harness-check.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# harness: reusable
 # Frontmatter linter for the agent-harness layer model.
 #
 # Verifies every .agents/agents/*.md and .agents/rules/*.md file has a
@@ -36,7 +37,7 @@ REPO_ROOT="$(repo_root)"
 # --- Collect candidate files ---
 
 MD_FILES=""
-for d in ".agents/agents" ".agents/rules"; do
+for d in ".agents/agents" ".agents/rules" "dev"; do
   if [ -d "$REPO_ROOT/$d" ]; then
     set +e
     found=$(find "$REPO_ROOT/$d" -maxdepth 1 -type f -name "*.md" 2>/dev/null)
@@ -47,10 +48,14 @@ $found"
 done
 
 SH_YML_FILES=""
-for d in ".github/workflows" "dev/lib"; do
+for d in ".github/workflows" "dev/lib" "bin"; do
   if [ -d "$REPO_ROOT/$d" ]; then
     set +e
-    found=$(find "$REPO_ROOT/$d" -maxdepth 1 -type f \( -name "*.sh" -o -name "*.yml" \) 2>/dev/null)
+    if [ "$d" = "bin" ]; then
+      found=$(find "$REPO_ROOT/$d" -maxdepth 1 -type f \( -name "*.sh" -o -name "*.yml" -o ! -name "*.*" \) ! -name "test-*.sh" 2>/dev/null)
+    else
+      found=$(find "$REPO_ROOT/$d" -maxdepth 1 -type f \( -name "*.sh" -o -name "*.yml" \) ! -name "test-*.sh" 2>/dev/null)
+    fi
     set -e
     [ -n "$found" ] && SH_YML_FILES="$SH_YML_FILES
 $found"
@@ -78,7 +83,7 @@ done
 
 # --- Check .sh / .yml files (header comment: `# harness: <value>`) ---
 for f in $SH_YML_FILES; do
-  marker=$(grep -m1 '#[[:space:]]*harness:[[:space:]]*' "$f" 2>/dev/null | sed 's/.*harness:[[:space:]]*//' | tr -d '[:space:]')
+  marker=$(grep -m1 '^#[[:space:]]*harness:[[:space:]]*' "$f" 2>/dev/null | sed 's/.*harness:[[:space:]]*//' | tr -d '[:space:]')
   case "$marker" in
     reusable) COUNT_REUSABLE=$((COUNT_REUSABLE + 1)) ;;
     template) COUNT_TEMPLATE=$((COUNT_TEMPLATE + 1)) ;;

--- a/dev/agent-feature-workflow.md
+++ b/dev/agent-feature-workflow.md
@@ -1,5 +1,5 @@
 ---
-harness: reusable
+harness: template
 ---
 
 # Feature Agent Workflow


### PR DESCRIPTION
This PR addresses critical feedback from the first adoption of Agent Harness:

- **Issue #10:** Ensures `agent-harness-check.sh` is deployed to the target project's `bin/` directory during `init`.
- **Issue #11:** Genericizes all core agent definitions and rules by removing OCaml/JJ/Trading specificities and re-tagging them as `harness: template`.
- **Issue #12:** Re-tags `dev/agent-feature-workflow.md` as `template`.
- **Linter Improvements:** Updates the linter to check `dev/` and `bin/` and improves its robustness against false positives.