### PR TITLE
docs: add three-tier documentation system

### DIFF
--- a/.agents/rules/documentation-system.md
+++ b/.agents/rules/documentation-system.md
@@ -1,0 +1,132 @@
+---
+harness: reusable
+---
+
+# Documentation System
+
+A three-tier doc protocol for agent-driven repos: `CLAUDE.md` (operational
+instructions, repo root), `CONTEXT.md` (per-directory orientation,
+human-authored), `DEEP_DIVE.md` (per-directory exhaustive reference,
+model-generated and regenerable).
+
+The tiers serve different audiences and have different update cadences.
+Mixing them — e.g. putting architecture in `CLAUDE.md`, or hand-editing
+`DEEP_DIVE.md` — breaks the system.
+
+## CLAUDE.md (repo root, sometimes subsystem root)
+
+**Purpose:** operational instructions for agents working in this repo.
+
+**Contains:**
+- How to run tests, builds, linters (exact commands).
+- Build system specifics and query patterns.
+- Style conventions and forbidden patterns.
+- Where docs live and how to use them (the doc protocol below).
+- Pointer to the deep-dive generation prompt at
+  `docs/conventions/deep_dive_prompt.md`.
+
+**Excludes:** architecture, domain knowledge, per-directory specifics,
+glossary. Those belong in `CONTEXT.md` / `DEEP_DIVE.md` / `docs/cross_cutting/`.
+
+**Stays lean.** Read on every interaction; competes with the task for
+attention.
+
+**Doc protocol section (required in `CLAUDE.md`):**
+
+```
+When working in a directory:
+1. Read CONTEXT.md files from repo root down to the target directory.
+2. If DEEP_DIVE.md exists in the target, read it before reading source.
+3. If DEEP_DIVE.md disagrees with source, trust source and flag drift.
+4. Never edit DEEP_DIVE.md directly — it is regenerated.
+5. Edit CONTEXT.md to shape future regenerations.
+```
+
+## CONTEXT.md (per directory, human-authored, stable)
+
+**Purpose:** orientation. The "why" the model can't infer.
+
+**Length:** 200–400 words. One page max.
+
+**Required sections:**
+
+- **What this is** — one plain sentence, no jargon.
+- **Why it exists as its own module** — 2–3 sentences. The boundary
+  rationale.
+- **Components** — list subdirectories, ordered by importance, marked
+  **central** vs supporting, one sentence each.
+- **How it's used** — 1–2 most important callers with paths.
+- **What it is NOT** — common misconceptions. Optional but high-value.
+- **Stability** — one line. "Stable." / "Active redesign." / "Legacy."
+
+**Placement rule:** a directory gets a `CONTEXT.md` only when there's
+something to say that isn't covered by its parent's `CONTEXT.md`. Don't
+preemptively populate.
+
+**Updated by humans in code review.** Changes rarely.
+
+Skeleton: `docs/conventions/CONTEXT.template.md`.
+
+## DEEP_DIVE.md (per directory, model-generated, regenerable)
+
+**Purpose:** exhaustive cited reference.
+
+**Generation:** see `docs/conventions/deep_dive_prompt.md` for the full
+prompt (Steps 0–6, output structure, hard rules, self-check).
+
+**Output structure:**
+
+1. Purpose (uses `CONTEXT.md` framing verbatim).
+2. Mental Model (written LAST, after inventory).
+3. Public Surface (bullets with `path:line` and callers).
+4. Inbound Dependencies (grouped by top-level package).
+5. Outbound Dependencies (first-party / third-party / stdlib).
+6. **Subdirectory Deep Dives** — one subsection per subdir, length
+   proportional to subdir size.
+7. Top-Level Glue (brief, last).
+8. Data Flow (one numbered path with citations).
+9. Invariants (cited from comments / asserts only).
+10. Sharp Edges (cited from TODO / HACK / FIXME only).
+11. Tests (location, command, coverage gaps).
+12. Context Drift (contradictions between `CONTEXT.md` and code).
+13. Generation Metadata (date, VCS SHA, files-read count).
+
+**Hard rules:**
+
+- Every factual claim outside Purpose / Mental Model needs a `path:line`
+  citation.
+- No invention. Missing info → "Not found in scanned scope."
+- No filler words: robust, scalable, efficient, clean, modern, elegant.
+- No "etc.", "and so on", "among others" — complete the list or state the
+  count.
+- `<!-- HUMAN: -->` blocks must be preserved across regenerations.
+- No file trees, no exhaustive API listings.
+
+Skeleton: `docs/conventions/DEEP_DIVE.template.md`.
+
+## Update protocol
+
+- **`CLAUDE.md` and `CONTEXT.md`:** human edits in code review. Rare.
+- **`DEEP_DIVE.md`:** regenerated automatically when (a) >20% of files
+  changed, (b) build config changed, (c) `CONTEXT.md` changed, (d) >30 days
+  elapsed, or (e) manually triggered. PR opens automatically; human
+  reviews diff and merges.
+- **Never** hand-edit `DEEP_DIVE.md` outside `<!-- HUMAN: -->` blocks.
+  Hand edits get destroyed by regeneration, which makes regeneration stop
+  happening, which makes the doc rot forever.
+- **Staleness signal:** Generation Metadata records the VCS SHA. CI
+  compares to HEAD and warns if the directory has changed substantially
+  since.
+- **Drift signal:** accumulating Context Drift entries mean either the
+  code or `CONTEXT.md` is wrong. Treat as debt.
+
+## Coverage policy
+
+- Not every directory needs a `DEEP_DIVE.md`. Pick by: high agent
+  traffic, high onboarding cost, high blast radius, complex non-obvious
+  domain logic.
+- Many directories need only a `CONTEXT.md`. Many need nothing.
+- Cross-directory concerns (multi-package flows, shared invariants) go
+  in `docs/cross_cutting/`, not in any single deep dive.
+- Maintain `docs/index.md` auto-generated from `CONTEXT.md` files for
+  discoverability.

--- a/.agents/rules/documentation-system.md
+++ b/.agents/rules/documentation-system.md
@@ -31,6 +31,8 @@ glossary. Those belong in `CONTEXT.md` / `DEEP_DIVE.md` / `docs/cross_cutting/`.
 **Stays lean.** Read on every interaction; competes with the task for
 attention.
 
+Skeleton: `docs/conventions/CLAUDE.template.md`.
+
 **Doc protocol section (required in `CLAUDE.md`):**
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,22 @@ references). The harness layer is loaded on top and provides the
 orchestration. The two CLAUDE.md files do not conflict — one is about
 the project, one is about the agentic harness.
 
+## Documentation system
+
+This harness ships a three-tier doc protocol. Full rules in
+`.agents/rules/documentation-system.md`; generation prompt and
+skeletons in `docs/conventions/`.
+
+When working in a directory:
+
+1. Read `CONTEXT.md` files from repo root down to the target directory.
+2. If `DEEP_DIVE.md` exists in the target, read it before reading
+   source.
+3. If `DEEP_DIVE.md` disagrees with source, trust source and flag
+   drift.
+4. Never edit `DEEP_DIVE.md` directly — it is regenerated.
+5. Edit `CONTEXT.md` to shape future regenerations.
+
 ## Source
 
 Extracted from a production system on 2026-04-26 per

--- a/docs/conventions/CLAUDE.template.md
+++ b/docs/conventions/CLAUDE.template.md
@@ -1,0 +1,83 @@
+# <Project Name> — Agent Instructions
+
+<!--
+  CLAUDE.md skeleton for a CONSUMING PROJECT.
+  Lives at the project repo root (and optionally at subsystem roots).
+  Loaded on every agent interaction — keep lean. Architecture, domain,
+  and per-directory specifics belong in CONTEXT.md / DEEP_DIVE.md, not
+  here. See .agents/rules/documentation-system.md for the full rules.
+-->
+
+## What this repo is
+
+<One paragraph. What the project does, who runs it, what it produces.>
+
+## Build / test / lint
+
+Exact commands an agent can copy-paste. No prose.
+
+```bash
+# build
+<build_cmd>
+
+# test (full suite)
+<test_cmd>
+
+# test (single target)
+<single_test_cmd>
+
+# lint
+<lint_cmd>
+
+# format
+<format_cmd>
+```
+
+If commands run inside a container or env wrapper, document it once
+here:
+
+```bash
+<env_wrapper_cmd> -- <build_cmd>
+```
+
+## Build system specifics
+
+<Query patterns, target naming conventions, anything an agent needs
+to navigate the build graph. Examples: `bazel query`, workspace
+layout, monorepo path conventions, generated-code locations. Keep to
+bullets.>
+
+- <Pattern 1>.
+- <Pattern 2>.
+
+## Style conventions
+
+<Forbidden patterns, required patterns, naming rules. Bullets, not
+prose.>
+
+- <Convention 1>.
+- <Forbidden pattern 1>.
+
+## Documentation system
+
+This project uses the three-tier doc protocol from the agent-harness.
+Full rules in `.agents/rules/documentation-system.md`; skeletons in
+`docs/conventions/`; generation prompt at
+`docs/conventions/deep_dive_prompt.md`.
+
+When working in a directory:
+
+1. Read `CONTEXT.md` files from repo root down to the target directory.
+2. If `DEEP_DIVE.md` exists in the target, read it before reading
+   source.
+3. If `DEEP_DIVE.md` disagrees with source, trust source and flag
+   drift.
+4. Never edit `DEEP_DIVE.md` directly — it is regenerated.
+5. Edit `CONTEXT.md` to shape future regenerations.
+
+## Agent harness
+
+This repo is wired to the `agent-harness` orchestration framework.
+Auto-discover your role by reading the relevant playbook in
+`.agents/agents/` (e.g. `lead-orchestrator.md`,
+`feat-<your-track>.md`, `qc-structural.md`).

--- a/docs/conventions/CONTEXT.template.md
+++ b/docs/conventions/CONTEXT.template.md
@@ -1,0 +1,47 @@
+# <Directory Name>
+
+<!--
+  CONTEXT.md skeleton. Copy into the target directory and fill in.
+  Length: 200-400 words. One page max.
+  See .agents/rules/documentation-system.md for the full rules.
+-->
+
+## What this is
+
+<One plain sentence, no jargon. What this directory is, in terms a new
+contributor would understand on day one.>
+
+## Why it exists as its own module
+
+<2-3 sentences. The boundary rationale — why is this its own directory
+rather than folded into a sibling? What does it protect, hide, or
+isolate?>
+
+## Components
+
+<List immediate subdirectories, ordered by importance, marked
+**central** vs supporting, one sentence each.>
+
+- **`<subdir-1>/`** — central. <One sentence on what it owns.>
+- **`<subdir-2>/`** — central. <One sentence.>
+- `<subdir-3>/` — supporting. <One sentence.>
+
+## How it's used
+
+<1-2 most important callers, with paths. Not an exhaustive list —
+just the load-bearing ones a reader needs to know about.>
+
+- `<path/to/caller-1>` — <how it consumes this module>.
+- `<path/to/caller-2>` — <how it consumes this module>.
+
+## What it is NOT
+
+<Optional but high-value. Common misconceptions, things this module is
+mistaken for, scope boundaries.>
+
+- Not <a thing people assume>.
+- Not <another thing>.
+
+## Stability
+
+<One line.> Stable. / Active redesign. / Legacy.

--- a/docs/conventions/DEEP_DIVE.template.md
+++ b/docs/conventions/DEEP_DIVE.template.md
@@ -1,0 +1,99 @@
+# <Directory Name> — Deep Dive
+
+<!--
+  DEEP_DIVE.md skeleton. This file is MODEL-GENERATED and REGENERABLE.
+  Do not hand-edit outside <!-- HUMAN: --> blocks. See
+  .agents/rules/documentation-system.md and
+  docs/conventions/deep_dive_prompt.md.
+-->
+
+## Purpose
+
+<Verbatim from CONTEXT.md "What this is" + "Why it exists as its own
+module".>
+
+## Mental Model
+
+<Written LAST, after inventory. The compressed shape of the module —
+what's in your head after reading it cold. 3-6 sentences.>
+
+## Public Surface
+
+- `<path/to/file>:<line>` — `<symbol>` — <one-line role>. Callers:
+  `<caller-1>`, `<caller-2>`.
+- `<path/to/file>:<line>` — `<symbol>` — <one-line role>. Callers:
+  Not found in scanned scope.
+
+## Inbound Dependencies
+
+Grouped by top-level package.
+
+- **`<top-level-pkg-a>`** — `<path>:<line>`, `<path>:<line>`.
+- **`<top-level-pkg-b>`** — `<path>:<line>`.
+
+## Outbound Dependencies
+
+- **First-party:** `<pkg>`, `<pkg>`.
+- **Third-party:** `<pkg>` (`<version-or-constraint>`), `<pkg>`.
+- **Stdlib:** `<module>`, `<module>`.
+
+## Subdirectory Deep Dives
+
+### `<subdir-1>/` — central
+
+<Length proportional to subdir size from the Step 1 census. Cite
+`path:line` for every factual claim.>
+
+### `<subdir-2>/` — central
+
+<...>
+
+### `<subdir-3>/` — supporting
+
+<...>
+
+## Top-Level Glue
+
+<Brief. Shorter than any single subdirectory subsection. Re-exports,
+registration, entry points.>
+
+## Data Flow
+
+One numbered path through the module, with citations.
+
+1. <Caller> calls `<symbol>` (`<path>:<line>`).
+2. `<symbol>` dispatches to `<symbol-2>` (`<path>:<line>`).
+3. <...>
+
+## Invariants
+
+Cited from comments or asserts only.
+
+- <Invariant statement> — `<path>:<line>`.
+
+## Sharp Edges
+
+Cited from TODO / HACK / FIXME only.
+
+- `<path>:<line>` — <quoted comment, brief>.
+
+## Tests
+
+- **Location:** `<path>`.
+- **Command:** `<exact command to run>`.
+- **Coverage gaps:** <symbols / paths not under test, or "Not found in
+  scanned scope.">.
+
+## Context Drift
+
+<Contradictions between CONTEXT.md and the code. Empty if clean.>
+
+- `CONTEXT.md` says <X>, but `<path>:<line>` shows <Y>.
+
+<!-- HUMAN: pinned notes go here. Preserved across regenerations. -->
+
+## Generation Metadata
+
+- **Date:** `<YYYY-MM-DD>`
+- **VCS SHA:** `<sha>`
+- **Files read:** `<count>`

--- a/docs/conventions/deep_dive_prompt.md
+++ b/docs/conventions/deep_dive_prompt.md
@@ -1,0 +1,115 @@
+# DEEP_DIVE.md Generation Prompt
+
+The exact prompt body the model uses to (re)generate a directory's
+`DEEP_DIVE.md`. Edit per language / build system in your consuming
+project. The meta-rules (purpose, placement, update cadence) live in
+`.agents/rules/documentation-system.md`.
+
+---
+
+You are generating `DEEP_DIVE.md` for a target directory. Follow Steps
+0–6 in order. Do not skip steps. Do not invent. Cite every factual
+claim.
+
+## Step 0 — Read context
+
+Read `CONTEXT.md` from repo root down to the target directory. If the
+target's `CONTEXT.md` is missing, **STOP and report**. Do not proceed
+without it — orientation is a prerequisite, not optional.
+
+## Step 1 — Subdirectory census FIRST
+
+List immediate subdirectories with file count and total line count,
+sorted descending by line count. This list is your priority order.
+
+Output format:
+
+```
+| Subdir | Files | Lines |
+|--------|-------|-------|
+| <name> | <n>   | <n>   |
+```
+
+## Step 2 — Top-level file census SECOND
+
+Classify each top-level file as one of:
+
+- re-export
+- registration
+- glue
+- shared types
+- entry point
+- substantive (rare — double-check before assigning this)
+
+## Step 3 — Allocate budget proportionally
+
+- Top 3 subdirs: ~60% of reading.
+- Remaining subdirs: ~30%.
+- Top-level files: ~10%.
+- Read at least 2 files from every subdir over 200 lines.
+- Output the allocation as a table BEFORE writing prose.
+
+## Step 4 — Read build files before source
+
+Read `BUILD` / `package.json` / `Cargo.toml` / `pyproject.toml` /
+equivalent first. They give the authoritative dependency contract;
+source imports can lie or be transitively shadowed.
+
+## Step 5 — Reverse-dependency search
+
+Use the build system's reverse-dep query if available (e.g. `bazel
+query 'rdeps(//..., //target/...)'`), else `grep` for imports of the
+target package across the repo. Record up to 20 distinct callers,
+grouped by top-level package.
+
+## Step 6 — Symbol census
+
+`grep` for all public symbols defined in the target. Every symbol must
+either appear in the doc or be marked "internal helper." Coverage gap
+is a generation failure.
+
+---
+
+## Output structure
+
+Write the doc in this exact order:
+
+1. **Purpose** — uses `CONTEXT.md` framing verbatim.
+2. **Mental Model** — written LAST, after the inventory is complete.
+3. **Public Surface** — bullets with `path:line` and callers.
+4. **Inbound Dependencies** — grouped by top-level package.
+5. **Outbound Dependencies** — first-party / third-party / stdlib.
+6. **Subdirectory Deep Dives** — one subsection per subdir, length
+   proportional to subdir size from Step 1.
+7. **Top-Level Glue** — brief, last.
+8. **Data Flow** — one numbered path with citations.
+9. **Invariants** — cited from comments / asserts only.
+10. **Sharp Edges** — cited from TODO / HACK / FIXME only.
+11. **Tests** — location, command, coverage gaps.
+12. **Context Drift** — contradictions between `CONTEXT.md` and code.
+13. **Generation Metadata** — date, VCS SHA, files-read count.
+
+## Hard rules
+
+- Every factual claim outside Purpose / Mental Model needs a
+  `path:line` citation.
+- No invention. Missing info → "Not found in scanned scope."
+- No filler words: robust, scalable, efficient, clean, modern,
+  elegant.
+- No "etc.", "and so on", "among others" — complete the list or state
+  the count.
+- `<!-- HUMAN: -->` blocks must be preserved verbatim across
+  regenerations.
+- No file trees. No exhaustive API listings.
+
+## Self-check before finishing
+
+- **File coverage:** 100% of source files mentioned by path.
+- **Symbol coverage:** ≥80% of public symbols accounted for.
+- **Subdirectory balance:** longest subsection / shortest non-trivial
+  subsection < 10×.
+- **Top-Level Glue** section shorter than any single subdirectory
+  subsection.
+- **Citation density:** 9/10 random factual sentences have `path:line`.
+
+If any check fails, fix before writing the file.


### PR DESCRIPTION
## Summary
- Adds `.agents/rules/documentation-system.md` (`harness: reusable`) — full ruleset for the `CLAUDE.md` / `CONTEXT.md` / `DEEP_DIVE.md` tiers, update protocol, coverage policy.
- Adds `docs/conventions/deep_dive_prompt.md` — exact generation prompt (Steps 0–6, output structure, hard rules, self-check) the model uses to (re)generate `DEEP_DIVE.md` for a target directory.
- Adds `docs/conventions/CONTEXT.template.md` and `docs/conventions/DEEP_DIVE.template.md` — skeletons consuming projects copy into their target directories.
- Patches root `CLAUDE.md` with the 5-line doc protocol and pointers to the rules + templates.

No new agent shipped — consuming projects wire regen into their own orchestrator / CI when ready.

## Test plan
- [x] `bin/agent-harness-check.sh` passes (18 files tagged: 8 reusable, 9 template, 1 project).
- [ ] Manually skim `CONTEXT.template.md` / `DEEP_DIVE.template.md` rendered on GitHub for header / placeholder readability.
- [ ] Confirm root `CLAUDE.md` doc-protocol section is the right length (lean — competes with task attention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)