### PR TITLE
fix(init): preserve user .gitignore/CLAUDE.md, drop stale stub comment

### DIFF
--- a/bin/agent-harness
+++ b/bin/agent-harness
@@ -9,11 +9,6 @@
 #   agent-harness help                       This message.
 #
 # Exit code: 0 on success, 1 on any error.
-#
-# Status: stub. `init` and `sync` are placeholders; only `check` and
-# `help` are functional. Implementation is being driven by real
-# bootstrap of the second consuming project — see the agent-harness
-# repo's open issues / follow-ups for current state.
 
 set -eu
 
@@ -64,7 +59,20 @@ cmd_init() {
   cp "$HARNESS_ROOT/dev/agent-feature-workflow-example.md" "$target/dev/"
   cp "$HARNESS_ROOT/.claude/settings.json" "$target/.claude/"
   cp "$HARNESS_ROOT/.antigravityignore" "$target/"
-  cp "$HARNESS_ROOT/CLAUDE.md" "$target/"
+
+  if [ -e "$target/.gitignore" ]; then
+    echo "WARN: $target/.gitignore exists; harness .gitignore saved as .gitignore.harness-template (merge entries manually)" >&2
+    cp "$HARNESS_ROOT/.gitignore" "$target/.gitignore.harness-template"
+  else
+    cp "$HARNESS_ROOT/.gitignore" "$target/.gitignore"
+  fi
+
+  if [ -e "$target/CLAUDE.md" ]; then
+    echo "WARN: $target/CLAUDE.md exists; harness CLAUDE.md saved as CLAUDE.md.harness-template (merge manually)" >&2
+    cp "$HARNESS_ROOT/CLAUDE.md" "$target/CLAUDE.md.harness-template"
+  else
+    cp "$HARNESS_ROOT/CLAUDE.md" "$target/"
+  fi
   cp -a "$HARNESS_ROOT/.geminirules" "$target/" || true
   cp -a "$HARNESS_ROOT/.cursorrules" "$target/" || true
 


### PR DESCRIPTION
Closes #14.

## Summary
- `.gitignore` is now copied during `agent-harness init`. On collision, original is preserved and harness version saved as `.gitignore.harness-template` with stderr warn.
- `CLAUDE.md` no longer silently clobbers an existing project `CLAUDE.md`. Same diversion pattern as `.gitignore`.
- Removed the "Status: stub" header comment in `bin/agent-harness` (lines 12–16). It contradicted the implemented code, the `usage()` text, and the README's "all three subcommands implemented" statement.

## Test plan
- [x] Smoke-tested `init` into a clean tmp dir → both `.gitignore` and `CLAUDE.md` copied.
- [x] Smoke-tested `init` into a tmp dir with pre-existing `.gitignore` and `CLAUDE.md` → originals untouched, harness versions saved as `*.harness-template`, warnings printed to stderr.
- [x] `bin/agent-harness-check.sh` still passes (17 files, 7 reusable / 9 template / 1 project).
- [ ] Reviewer eyeballs the diff; collision-handling pattern matches the suggestion in #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)